### PR TITLE
Feat/order size

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -193,7 +193,7 @@ class Strategy(metaclass=ABCMeta):
         one at take-profit price (`tp`; limit order).
 
         If `price` is not set, market price is assumed.
-        
+
         If `size` is not set, entire holding cash is assumed.
         """
         self._broker.buy(price and float(price),
@@ -211,7 +211,7 @@ class Strategy(metaclass=ABCMeta):
         one at take-profit price (`tp`; limit order).
 
         If `price` is not set, market price is assumed.
-        
+
         If `size` is not set, entire holding cash is assumed.
         """
         self._broker.sell(price and float(price),
@@ -469,11 +469,11 @@ class _Broker:
     def __repr__(self):
         return '<Broker: {:.0f}{:+.1f}>'.format(self._cash, self.position.pl)
 
-    def buy(self, price=None, sl=None, tp=None, size:float=None):
+    def buy(self, price=None, sl=None, tp=None, size: float = None):
         assert (sl or -np.inf) <= (price or self.last_close) <= (tp or np.inf), "For long orders should be: SL ({}) < BUY PRICE ({}) < TP ({})".format(sl, price or self.last_close, tp)  # noqa: E501
         self.orders._update(price, sl, tp, size)
 
-    def sell(self, price=None, sl=None, tp=None, size:float=None):
+    def sell(self, price=None, sl=None, tp=None, size: float = None):
         assert (tp or -np.inf) <= (price or self.last_close) <= (sl or np.inf), "For short orders should be: TP ({}) < BUY PRICE ({}) < SL ({})".format(tp, price or self.last_close, sl)  # noqa: E501
         self.orders._update(price, sl, tp, size, is_long=False)
 
@@ -503,7 +503,7 @@ class _Broker:
 
         i, price = self._get_market_price(price)
 
-        size = self._cash if self.orders._size == None else self.orders._size
+        size = self._cash if self.orders._size is None else self.orders._size
         position = float(size * self._leverage / (price * (1 + self._commission)))
         self._position = position if is_long else -position
         self._position_open_price = price

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -193,6 +193,8 @@ class Strategy(metaclass=ABCMeta):
         one at take-profit price (`tp`; limit order).
 
         If `price` is not set, market price is assumed.
+        
+        If `size` is not set, entire holding cash is assumed.
         """
         self._broker.buy(price and float(price),
                          sl and float(sl),
@@ -209,6 +211,8 @@ class Strategy(metaclass=ABCMeta):
         one at take-profit price (`tp`; limit order).
 
         If `price` is not set, market price is assumed.
+        
+        If `size` is not set, entire holding cash is assumed.
         """
         self._broker.sell(price and float(price),
                           sl and float(sl),

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -270,6 +270,17 @@ class TestBacktest(TestCase):
                 if self.position:
                     self.position.close()
 
+        class SingleFixedSizeTrade(Strategy):
+            def init(self):
+                self._done = False
+
+            def next(self):
+                if not self._done:
+                    self.buy(size=1000)
+                    self._done = True
+                if self.position:
+                    self.position.close()
+
         class SinglePosition(Strategy):
             def init(self):
                 pass
@@ -287,6 +298,7 @@ class TestBacktest(TestCase):
 
         for strategy in (SmaCross,
                          SingleTrade,
+                         SingleFixedSizeTrade,
                          SinglePosition,
                          NoTrade):
             with self.subTest(strategy=strategy.__name__):


### PR DESCRIPTION
Added order sizing feature. Usage is as per discussion in #3 

Opted to use absolute position size instead of a percentage based off holding cash.

Ran with the code on the example, with a tweak on sizing:

```python
from backtesting import Backtest, Strategy
from backtesting.lib import crossover

from backtesting.test import SMA, GOOG


class SmaCross(Strategy):
    n1 = 10
    n2 = 30

    def init(self):
        self.sma1 = self.I(SMA, self.data.Close, self.n1)
        self.sma2 = self.I(SMA, self.data.Close, self.n2)

    def next(self):
        if crossover(self.sma1, self.sma2):
            self.buy(size=1000)
        elif crossover(self.sma2, self.sma1):
            self.sell(size=1000)


bt = Backtest(GOOG, SmaCross, cash=10000, commission=.002)

output = bt.run()
bt.plot()
```

On a quick eyeball, it seems to work.

Did write one simple test. Let me know if there needs be further coverage.
