### PR TITLE
fix typo in 'commision'

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -958,7 +958,7 @@ class Backtest:
 
         `cash` is the initial cash to start with.
 
-        `commission` is the commision ratio. E.g. if your broker's commission
+        `commission` is the commission ratio. E.g. if your broker's commission
         is 1% of trade value, set commission to `0.01`. Note, if you wish to
         account for bid-ask spread, you cam approximate doing so by increasing
         the commission, e.g. set it to `0.0002` for commission-less forex


### PR DESCRIPTION
Tiny typo fix in the docs. I swear there was another one, like 'com' instead of 'come' somewhere, but I couldn't find it.