### PR TITLE
Update stats calc for buy and hold to be long-only

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1380,7 +1380,7 @@ class Backtest:
         s.loc['Equity Peak [$]'] = equity.max()
         s.loc['Return [%]'] = (equity[-1] - equity[0]) / equity[0] * 100
         c = data.Close.values
-        s.loc['Buy & Hold Return [%]'] = abs(c[-1] - c[0]) / c[0] * 100  # long OR short
+        s.loc['Buy & Hold Return [%]'] = (c[-1] - c[0]) / c[0] * 100  # long-only return
         s.loc['Max. Drawdown [%]'] = max_dd = -np.nan_to_num(dd.max()) * 100
         s.loc['Avg. Drawdown [%]'] = -dd_peaks.mean() * 100
         s.loc['Max. Drawdown Duration'] = _round_timedelta(dd_dur.max())


### PR DESCRIPTION
Changed the "Buy & Hold" stats calculation to remove the absolute value function.  It will now reflect a negative number if the underlying asset has a negative return for the comparison period.

Fixes https://github.com/kernc/backtesting.py/issues/150.