### PR TITLE
Plot `show_legend = False` fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,4 +62,4 @@ Please use explicit commit messages. See [NumPy's development workflow]
 for inspiration.
 
 [code-review]: https://mtlynch.io/code-review-love/
-[NumPy's development workflow]: https://docs.scipy.org/doc/numpy/dev/gitwash/development_workflow.html
+[NumPy's development workflow]: https://numpy.org/doc/stable/dev/development_workflow.html

--- a/backtesting/_plotting.py
+++ b/backtesting/_plotting.py
@@ -615,7 +615,8 @@ return this.labels[index] || "";
 
     for f in plots:
         if f.legend:
-            f.legend.location = 'top_left' if show_legend else None
+            f.legend.visible = show_legend
+            f.legend.location = 'top_left'
             f.legend.border_line_width = 1
             f.legend.border_line_color = '#333333'
             f.legend.padding = 5

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -642,6 +642,14 @@ class TestPlot(TestCase):
                 with self.subTest(param=p[0]):
                     bt.plot(**dict([p]), filename=f, open_browser=False)
 
+    def test_hide_legend(self):
+        bt = Backtest(GOOG.iloc[:100], SmaCross)
+        bt.run()
+        with _tempfile() as f:
+            bt.plot(filename=f, show_legend=False)
+            # Give browser time to open before tempfile is removed
+            time.sleep(10)
+            
     def test_resolutions(self):
         with _tempfile() as f:
             for rule in 'LSTHDWM':

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -648,7 +648,7 @@ class TestPlot(TestCase):
         with _tempfile() as f:
             bt.plot(filename=f, show_legend=False)
             # Give browser time to open before tempfile is removed
-            time.sleep(10)
+            time.sleep(5)
 
     def test_resolutions(self):
         with _tempfile() as f:

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -649,7 +649,7 @@ class TestPlot(TestCase):
             bt.plot(filename=f, show_legend=False)
             # Give browser time to open before tempfile is removed
             time.sleep(10)
-            
+
     def test_resolutions(self):
         with _tempfile() as f:
             for rule in 'LSTHDWM':


### PR DESCRIPTION
Made changes regarding bug #204 based on update to bokeh no longer using `legend.location = None` I also added a test function to display to browser.  (I've never worked with tests so, I'm sure this was done incorrectly @kernc) your test_params test sent everything to temp files which I didn't quite know how to access so I just created a separate one that sent the output to the browser.

Fixes https://github.com/kernc/backtesting.py/issues/204

