### PR TITLE
ENH: Add tqdm to skopt optimization

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -39,6 +39,18 @@ __pdoc__ = {
 }
 
 
+class SkoptProgressBar:
+    """
+    Progress bar using tqdm for scikit-optimize
+    Open feature request: https://github.com/scikit-optimize/scikit-optimize/issues/674
+    """
+    def __init__(self, **kwargs):
+        self._tqdm = _tqdm(**kwargs)
+
+    def __call__(self, result):
+        self._tqdm.update()
+
+
 class Strategy(metaclass=ABCMeta):
     """
     A trading strategy base class. Extend this class and
@@ -1446,7 +1458,7 @@ class Backtest:
                     kappa=3,
                     n_initial_points=min(max_tries, 20 + 3 * len(kwargs)),
                     initial_point_generator='lhs',  # 'sobel' requires n_initial_points ~ 2**N
-                    callback=DeltaXStopper(9e-7),
+                    callback=[DeltaXStopper(9e-7), SkoptProgressBar(desc="Sequential optimisation using decision trees.")],
                     random_state=random_state)
 
             stats = self.run(**dict(zip(kwargs.keys(), res.x)))

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1448,7 +1448,7 @@ class Backtest:
                     kappa=3,
                     n_initial_points=min(max_tries, 20 + 3 * len(kwargs)),
                     initial_point_generator='lhs',  # 'sobel' requires n_initial_points ~ 2**N
-                    callback=[DeltaXStopper(9e-7)],
+                    callback=DeltaXStopper(9e-7),
                     random_state=random_state)
 
             stats = self.run(**dict(zip(kwargs.keys(), res.x)))

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1352,7 +1352,7 @@ class Backtest:
                     with ProcessPoolExecutor() as executor:
                         futures = [executor.submit(Backtest._mp_task, backtest_uuid, i)
                                    for i in range(len(param_batches))]
-                        for future in _tqdm(as_completed(futures), total=len(futures)):
+                        for future in _tqdm(as_completed(futures), total=len(futures), description="Backtest.grid"):
                             batch_index, values = future.result()
                             for value, params in zip(values, param_batches[batch_index]):
                                 heatmap[tuple(params.values())] = value
@@ -1420,7 +1420,7 @@ class Backtest:
 
             # np.inf/np.nan breaks sklearn, np.finfo(float).max breaks skopt.plots.plot_objective
             INVALID = 1e300
-            skopt_pbar = _tqdm(dimensions, total=max_tries, desc="Skopt optimizations")
+            skopt_pbar = _tqdm(dimensions, total=max_tries, desc="Backtest.optimize")
 
             @use_named_args(dimensions=dimensions)
             def objective_function(**params):

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1352,11 +1352,8 @@ class Backtest:
                     with ProcessPoolExecutor() as executor:
                         futures = [executor.submit(Backtest._mp_task, backtest_uuid, i)
                                    for i in range(len(param_batches))]
-                        for future in _tqdm(
-                            as_completed(futures),
-                            total=len(futures),
-                            desc='Backtest.grid'
-                        ):
+                        for future in _tqdm(as_completed(futures), total=len(futures),
+                                            desc='Backtest.optimize'):
                             batch_index, values = future.result()
                             for value, params in zip(values, param_batches[batch_index]):
                                 heatmap[tuple(params.values())] = value

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1352,7 +1352,11 @@ class Backtest:
                     with ProcessPoolExecutor() as executor:
                         futures = [executor.submit(Backtest._mp_task, backtest_uuid, i)
                                    for i in range(len(param_batches))]
-                        for future in _tqdm(as_completed(futures), total=len(futures), desc='Backtest.grid'):
+                        for future in _tqdm(
+                            as_completed(futures),
+                            total=len(futures),
+                            desc='Backtest.grid'
+                        ):
                             batch_index, values = future.result()
                             for value, params in zip(values, param_batches[batch_index]):
                                 heatmap[tuple(params.values())] = value

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1352,7 +1352,7 @@ class Backtest:
                     with ProcessPoolExecutor() as executor:
                         futures = [executor.submit(Backtest._mp_task, backtest_uuid, i)
                                    for i in range(len(param_batches))]
-                        for future in _tqdm(as_completed(futures), total=len(futures), description="Backtest.grid"):
+                        for future in _tqdm(as_completed(futures), total=len(futures), description='Backtest.grid'):
                             batch_index, values = future.result()
                             for value, params in zip(values, param_batches[batch_index]):
                                 heatmap[tuple(params.values())] = value
@@ -1420,7 +1420,7 @@ class Backtest:
 
             # np.inf/np.nan breaks sklearn, np.finfo(float).max breaks skopt.plots.plot_objective
             INVALID = 1e300
-            skopt_pbar = _tqdm(dimensions, total=max_tries, desc="Backtest.optimize")
+            skopt_pbar = _tqdm(dimensions, total=max_tries, desc='Backtest.optimize')
 
             @use_named_args(dimensions=dimensions)
             def objective_function(**params):

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1458,7 +1458,10 @@ class Backtest:
                     kappa=3,
                     n_initial_points=min(max_tries, 20 + 3 * len(kwargs)),
                     initial_point_generator='lhs',  # 'sobel' requires n_initial_points ~ 2**N
-                    callback=[DeltaXStopper(9e-7), SkoptProgressBar(desc="Sequential optimisation using decision trees.")],
+                    callback=[
+                        DeltaXStopper(9e-7),
+                        SkoptProgressBar(desc="Sequential optimisation using decision trees.")
+                    ],
                     random_state=random_state)
 
             stats = self.run(**dict(zip(kwargs.keys(), res.x)))

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1352,7 +1352,7 @@ class Backtest:
                     with ProcessPoolExecutor() as executor:
                         futures = [executor.submit(Backtest._mp_task, backtest_uuid, i)
                                    for i in range(len(param_batches))]
-                        for future in _tqdm(as_completed(futures), total=len(futures), description='Backtest.grid'):
+                        for future in _tqdm(as_completed(futures), total=len(futures), desc='Backtest.grid'):
                             batch_index, values = future.result()
                             for value, params in zip(values, param_batches[batch_index]):
                                 heatmap[tuple(params.values())] = value
@@ -1420,12 +1420,11 @@ class Backtest:
 
             # np.inf/np.nan breaks sklearn, np.finfo(float).max breaks skopt.plots.plot_objective
             INVALID = 1e300
-            skopt_pbar = _tqdm(dimensions, total=max_tries, desc='Backtest.optimize')
+            progress = iter(_tqdm(repeat(None), total=max_tries, desc='Backtest.optimize'))
 
             @use_named_args(dimensions=dimensions)
             def objective_function(**params):
-                if hasattr(skopt_pbar, "update"):
-                    skopt_pbar.update(1)
+                next(progress)
                 # Check constraints
                 # TODO: Adjust after https://github.com/scikit-optimize/scikit-optimize/pull/971
                 if not constraint(AttrDict(params)):

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1460,7 +1460,7 @@ class Backtest:
                     initial_point_generator='lhs',  # 'sobel' requires n_initial_points ~ 2**N
                     callback=[
                         DeltaXStopper(9e-7),
-                        SkoptProgressBar(desc="Sequential optimisation using decision trees.")
+                        SkoptProgressBar(total=max_tries, desc="Skopt optimizations")
                     ],
                     random_state=random_state)
 

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1420,11 +1420,12 @@ class Backtest:
 
             # np.inf/np.nan breaks sklearn, np.finfo(float).max breaks skopt.plots.plot_objective
             INVALID = 1e300
-            skopt_pbar = _tqdm(total=max_tries, desc="Skopt optimizations")
+            skopt_pbar = _tqdm(dimensions, total=max_tries, desc="Skopt optimizations")
 
             @use_named_args(dimensions=dimensions)
             def objective_function(**params):
-                skopt_pbar.update(1)
+                if hasattr(skopt_pbar, "update"):
+                    skopt_pbar.update(1)
                 # Check constraints
                 # TODO: Adjust after https://github.com/scikit-optimize/scikit-optimize/pull/971
                 if not constraint(AttrDict(params)):


### PR DESCRIPTION
Resolves #280 

Added `tqdm` progress bar to `skopt` optimization runs .

TODO:
- [x] Review/test in notebook + terminal (briefly tested in IDE)
  - [x] Jupyterlab `3.0.12`
  - [x] Jupyter notebook `6.2.0`
  - [x] Terminal
- [ ] ~~Write new test to account for failing coverage threshold~~

Screenshot in Jupyterlab. `Skopt optimizations` is for the change in this PR, plays nicely with other progress bars if you use them.

![image](https://user-images.githubusercontent.com/8519081/111881680-107b3680-8988-11eb-9716-58c0a1239c1d.png)
