### PR TITLE
BUG: Handle _Array properties when pickling

### DIFF
--- a/backtesting/_plotting.py
+++ b/backtesting/_plotting.py
@@ -110,8 +110,8 @@ def _maybe_resample_data(resample_rule, df, indicators, equity_data, trades):
     indicators = [_Indicator(i.df.resample(freq, label='right').mean()
                              .dropna().reindex(df.index).values.T,
                              **dict(i._opts, name=i.name,
-                                    # HACK: override `data` for its index
-                                    data=pd.Series(np.nan, index=df.index)))
+                                    # Replace saved index with the resampled one
+                                    index=df.index))
                   for i in indicators]
     assert not indicators or indicators[0].df.index.equals(df.index)
 

--- a/backtesting/_util.py
+++ b/backtesting/_util.py
@@ -56,6 +56,16 @@ class _Array(np.ndarray):
             self.name = getattr(obj, 'name', '')
             self._opts = getattr(obj, '_opts', {})
 
+    # Make sure properties name and _opts are carried over
+    # when (un-)pickling.
+    def __reduce__(self):
+        value = super().__reduce__()
+        return value[:2] + (value[2] + (self.__dict__,),)
+
+    def __setstate__(self, state):
+        self.__dict__.update(state[-1])
+        super().__setstate__(state[:-1])
+
     def __bool__(self):
         try:
             return bool(self[-1])

--- a/backtesting/_util.py
+++ b/backtesting/_util.py
@@ -85,13 +85,14 @@ class _Array(np.ndarray):
     @property
     def s(self) -> pd.Series:
         values = np.atleast_2d(self)
-        return pd.Series(values[0], index=self._opts['data'].index, name=self.name)
+        index = self._opts['index'][:values.shape[1]]
+        return pd.Series(values[0], index=index, name=self.name)
 
     @property
     def df(self) -> pd.DataFrame:
         values = np.atleast_2d(np.asarray(self))
-        df = pd.DataFrame(values.T, index=self._opts['data'].index,
-                          columns=[self.name] * len(values))
+        index = self._opts['index'][:values.shape[1]]
+        df = pd.DataFrame(values.T, index=index, columns=[self.name] * len(values))
         return df
 
 
@@ -128,10 +129,11 @@ class _Data:
         self.__cache.clear()
 
     def _update(self):
-        self.__arrays = {col: _Array(arr, data=self)
+        index = self.__df.index.copy()
+        self.__arrays = {col: _Array(arr, index=index)
                          for col, arr in self.__df.items()}
         # Leave index as Series because pd.Timestamp nicer API to work with
-        self.__arrays['__index'] = self.__df.index.copy()
+        self.__arrays['__index'] = index
 
     def __repr__(self):
         i = min(self.__i, len(self.__df) - 1)

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -153,7 +153,7 @@ class Strategy(metaclass=ABCMeta):
         value = _Indicator(value, name=name, plot=plot, overlay=overlay,
                            color=color, scatter=scatter,
                            # _Indicator.s Series accessor uses this:
-                           data=self.data)
+                           index=self.data.index)
         self._indicators.append(value)
         return value
 

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -4,6 +4,7 @@ import sys
 import time
 import unittest
 import warnings
+from concurrent.futures.process import ProcessPoolExecutor
 from contextlib import contextmanager
 from glob import glob
 from runpy import run_path
@@ -898,6 +899,11 @@ class TestUtil(TestCase):
                 assert self.data.df['new_key'].equals(pd.Series(self.data.new_key, index=index))
 
         Backtest(GOOG.iloc[:20], S).run()
+
+    def test_indicators_picklable(self):
+        with ProcessPoolExecutor() as executor:
+            stats = executor.submit(Backtest.run, Backtest(SHORT_DATA, SmaCross)).result()
+        assert stats._strategy._indicators[0]._opts, '._opts and .name were not unpickled'
 
 
 class TestDocs(TestCase):

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -901,9 +901,11 @@ class TestUtil(TestCase):
         Backtest(GOOG.iloc[:20], S).run()
 
     def test_indicators_picklable(self):
+        bt = Backtest(SHORT_DATA, SmaCross)
         with ProcessPoolExecutor() as executor:
-            stats = executor.submit(Backtest.run, Backtest(SHORT_DATA, SmaCross)).result()
+            stats = executor.submit(Backtest.run, bt).result()
         assert stats._strategy._indicators[0]._opts, '._opts and .name were not unpickled'
+        bt.plot(results=stats, resample='2d', open_browser=False)
 
 
 class TestDocs(TestCase):


### PR DESCRIPTION
Fixes https://github.com/kernc/backtesting.py/issues/283 by (un-)pickling `_Array` properties also.

~~The remaining issue is `_Array._opts['data']: pd.DataFrame`, which is the original OHLC data, which might prove a strain to repeatedly (de-)serialize.~~ Worked around by saving only `.index` for 1/5 of the weight.