### PR TITLE
update batch sizes to minimize idle cores

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1333,8 +1333,7 @@ class Backtest:
                                     names=next(iter(param_combos)).keys()))
 
             def _batch(seq):
-                bs = np.ceil(len(seq) / (os.cpu_count() or 1)).astype(int)
-                n = np.clip(bs, 1, 300)
+                n = np.clip(int(np.ceil(len(seq) / (os.cpu_count() or 1))), 1, 300)
                 for i in range(0, len(seq), n):
                     yield seq[i:i + n]
 

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1333,7 +1333,8 @@ class Backtest:
                                     names=next(iter(param_combos)).keys()))
 
             def _batch(seq):
-                n = np.clip(len(seq) // (os.cpu_count() or 1), 5, 300)
+                bs = np.ceil(len(seq) / (os.cpu_count() or 1)).astype(int)
+                n = np.clip(bs, 1, 300)
                 for i in range(0, len(seq), n):
                     yield seq[i:i + n]
 


### PR DESCRIPTION
Previously, batch sizes during optimization could leave quite a few idle cores.  The changes in this PR ensures better cpu utilization.

### Before
Here are a few examples of what batch sizes would look like before this change (note number of idle cores):

|   length |   cpu_count |   minimum |   before_clip |   after_clip |   batches |   idle |
|---------:|------------:|----------:|--------------:|-------------:|----------:|-------:|
|     4000 |          38 |         5 |           106 |          106 |        38 |      0 |
|     4000 |          16 |         5 |           250 |          250 |        16 |      0 |
|     1000 |          38 |         5 |            27 |           27 |        38 |      0 |
|       60 |          38 |         5 |             2 |            5 |        12 |     26 |
|       60 |          16 |         5 |             4 |            5 |        12 |      4 |

---

### After
Same test dataset, but with proposed changes (minimizing idle cores):

|   length |   cpu_count |   minimum |   before_clip |   after_clip |   batches |   idle |
|---------:|------------:|----------:|--------------:|-------------:|----------:|-------:|
|     4000 |          38 |         1 |           106 |          106 |        38 |      0 |
|     4000 |          16 |         1 |           250 |          250 |        16 |      0 |
|     1000 |          38 |         1 |            27 |           27 |        38 |      0 |
|       60 |          38 |         1 |             2 |            2 |        30 |      8 |
|       60 |          16 |         1 |             4 |            4 |        15 |      1 |