### PR TITLE
Return plot when plotting output 

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1706,7 +1706,7 @@ class Backtest:
                 raise RuntimeError('First issue `backtest.run()` to obtain results.')
             results = self._results
 
-        plot(
+        return plot(
             results=results,
             df=self._data,
             indicators=results._strategy._indicators,


### PR DESCRIPTION
Hello, I had a [discussion](https://github.com/kernc/backtesting.py/discussions/405) about being able to save plots and that it would require to return plot figure to use export_png function. So, I made a pr for this.