### PR TITLE
[WIP] Feature: Support for multiple Instruments.

### DIFF
--- a/backtesting/_plotting.py
+++ b/backtesting/_plotting.py
@@ -5,11 +5,10 @@ import warnings
 from colorsys import hls_to_rgb, rgb_to_hls
 from itertools import cycle, combinations
 from functools import partial
-from typing import Callable, List, Union
+from typing import Callable, List, Union, Optional
 
 import numpy as np
 import pandas as pd
-
 from bokeh.colors import RGB
 from bokeh.colors.named import (
     lime as BULL_COLOR,
@@ -109,11 +108,11 @@ def _maybe_resample_data(resample_rule, df, indicators, equity_data, trades):
             "15T": 15,
             "30T": 30,
             "1H": 60,
-            "2H": 60*2,
-            "4H": 60*4,
-            "8H": 60*8,
-            "1D": 60*24,
-            "1W": 60*24*7,
+            "2H": 60 * 2,
+            "4H": 60 * 4,
+            "8H": 60 * 8,
+            "1D": 60 * 24,
+            "1W": 60 * 24 * 7,
             "1M": np.inf,
         })
         timespan = df.index[-1] - df.index[0]
@@ -147,6 +146,7 @@ def _maybe_resample_data(resample_rule, df, indicators, equity_data, trades):
                 mean_time = int(bars.loc[s.index].view(int).mean())
                 new_bar_idx = new_index.get_loc(mean_time, method='nearest')
                 return new_bar_idx
+
         return f
 
     if len(trades):  # Avoid pandas "resampling on Int64 index" error
@@ -162,7 +162,8 @@ def _maybe_resample_data(resample_rule, df, indicators, equity_data, trades):
 
 
 def plot(*, results: pd.Series,
-         df: pd.DataFrame,
+         df: Union[pd.DataFrame, dict[str, pd.DataFrame]],
+         instruments: Optional[list[str]] = None,
          indicators: List[_Indicator],
          filename='', plot_width=None,
          plot_equity=True, plot_return=False, plot_pl=True,
@@ -174,6 +175,7 @@ def plot(*, results: pd.Series,
     """
     Like much of GUI code everywhere, this is a mess.
     """
+    # fixme
     # We need to reset global Bokeh state, otherwise subsequent runs of
     # plot() contain some previous run's cruft data (was noticed when
     # TestPlot.test_file_size() test was failing).

--- a/backtesting/lib.py
+++ b/backtesting/lib.py
@@ -72,7 +72,7 @@ def barssince(condition: Sequence[bool], default=np.inf) -> int:
     Return the number of bars since `condition` sequence was last `True`,
     or if never, return `default`.
 
-        >>> barssince(self.data.Close > self.data.Open)
+        >>> barssince(self.df.Close > self.df.Open)
         3
     """
     return next(compress(range(len(condition)), reversed(condition)), default)
@@ -83,7 +83,7 @@ def cross(series1: Sequence, series2: Sequence) -> bool:
     Return `True` if `series1` and `series2` just crossed
     (above or below) each other.
 
-        >>> cross(self.data.Close, self.sma)
+        >>> cross(self.df.Close, self.sma)
         True
 
     """
@@ -95,7 +95,7 @@ def crossover(series1: Sequence, series2: Sequence) -> bool:
     Return `True` if `series1` just crossed over (above)
     `series2`.
 
-        >>> crossover(self.data.Close, self.sma)
+        >>> crossover(self.df.Close, self.sma)
         True
     """
     series1 = (
@@ -150,9 +150,9 @@ def quantile(series: Sequence, quantile: Union[None, float] = None):
     `series` at this quantile. If used to working with percentiles, just
     divide your percentile amount with 100 to obtain quantiles.
 
-        >>> quantile(self.data.Close[-20:], .1)
+        >>> quantile(self.df.Close[-20:], .1)
         162.130
-        >>> quantile(self.data.Close)
+        >>> quantile(self.df.Close)
         0.13
     """
     if quantile is None:


### PR DESCRIPTION
An incomplete attempt to add multiple-instrument backtest, which is mentioned in https://github.com/kernc/backtesting.py/issues/20 and https://github.com/kernc/backtesting.py/discussions/418

Aim: full backwards compatibility

How?
class `Backtest` will accept `data` as either a `pd.DataFrame` or a dictionary containing instrument names (`str`) and corresponding instrument data (`pd.DataFrame`). class `_Data` will follow suit.

class `_Data` will get a property `is_single_instrument` which tells us if the single-instrument-mode is enabled.

Internally, all classes will assume that the data is in multi-instrument mode. However, the signatures for methods in the existing API will be extended to return dictionaries instead of single-value if the multi-instrument mode is enabled.