### PR TITLE
support named indicator

### DIFF
--- a/backtesting/_plotting.py
+++ b/backtesting/_plotting.py
@@ -518,6 +518,8 @@ return this.labels[index] || "";
         ohlc_colors = colorgen()
         indicator_figs = []
 
+        named_indicator = {}
+
         for i, value in enumerate(indicators):
             value = np.atleast_2d(value)
 
@@ -528,11 +530,17 @@ return this.labels[index] || "";
 
             is_overlay = value._opts['overlay']
             is_scatter = value._opts['scatter']
-            if is_overlay:
-                fig = fig_ohlc
+            a_name = value._opts['named']
+            if a_name in named_indicator.keys():
+                fig = named_indicator[a_name]
             else:
-                fig = new_indicator_figure()
-                indicator_figs.append(fig)
+                if is_overlay:
+                    fig = fig_ohlc
+                else:
+                    fig = new_indicator_figure()
+                    indicator_figs.append(fig)
+                    if a_name is not None: named_indicator[a_name] = fig
+
             tooltips = []
             colors = value._opts['color']
             colors = colors and cycle(_as_list(colors)) or (

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -77,7 +77,7 @@ class Strategy(metaclass=ABCMeta):
 
     def I(self,  # noqa: E741, E743
           func: Callable, *args,
-          name=None, plot=True, overlay=None, color=None, scatter=False,
+          name=None, plot=True, overlay=None, color=None, scatter=False, named=None,
           **kwargs) -> np.ndarray:
         """
         Declare indicator. An indicator is just an array of values,


### PR DESCRIPTION
we can use named-indicator to make a goup;
so that,
 - two timeseries with different scale level can be viewed in different area
 - two timeseries with the scale level or relatived could be ploted together.

eg.
self.stddev   = self.I(SIGMA, self.data.Close, 30, TH.STDDEV,         overlay=False, named="stddev")
self.zscore   = self.I(SIGMA, self.data.Close, 30, TH.SIGMA,           overlay=False, named="zscore")
self.zpeak    = self.I(SIGMA, self.data.Close, 15, TH.SIGMA_PEAK, overlay=False, named="zscore")
self.zpeak    = self.I(SIGMA, self.data.Close, 30, TH.SIGMA_PEAK, overlay=False, named="zscore")
