### PR TITLE
Add `AutoTrader` to alternatives document

### DIFF
--- a/doc/alternatives.md
+++ b/doc/alternatives.md
@@ -10,6 +10,9 @@ If after reviewing the docs and examples perchance you find
 [_Backtesting.py_](https://kernc.github.io/backtesting.py) not your cup of tea,
 kindly have a look at some similar alternative Python backtesting frameworks:
 
+-  [AutoTrader](https://github.com/kieran-mackle/AutoTrader) -
+  an automated trading framework with an emphasis on cryptocurrency markets
+  that includes a [robust backtesting API](https://github.com/kieran-mackle/AutoTrader/blob/main/docs/source/tutorials/backtesting.md)
 - [bt](http://pmorissette.github.io/bt/) -
   a framework based on reusable and flexible blocks of
   strategy logic that support multiple instruments and


### PR DESCRIPTION
This PR expands the [alternatives documentation](https://github.com/kernc/backtesting.py/blob/master/doc/alternatives.md) by adding [AutoTrader](https://github.com/kieran-mackle/AutoTrader), an automated trading framework exposing a feature-rich backtesting API.