### PR TITLE
Optionally display rich progress bar when backtesting or optimizing.

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1373,7 +1373,12 @@ class Backtest:
                                 for i in range(len(param_batches))]
 
                         # Optional Rich progress bar 
-                        if show_progress: futures_iter = track(as_completed(futures), "Optimizing...", len(futures))
+                        if show_progress: futures_iter = track(
+                            as_completed(futures), 
+                            "Grid optimizing with fork multiprocessing...", 
+                            len(futures)
+                        )
+
                         else: futures_iter = as_completed(futures)
 
                         for future in futures_iter:
@@ -1387,7 +1392,10 @@ class Backtest:
 
                     # Optional Rich progress bar
                     batches_iter = range(len(param_batches))
-                    if show_progress: batches_iter = track(batches_iter, "Grid optimizing without multiprocessing...")
+                    if show_progress: batches_iter = track(
+                        batches_iter, 
+                        "Grid optimizing without multiprocessing..."
+                    )
 
                     for batch_index in batches_iter:
                         _, values = Backtest._mp_task(backtest_uuid, batch_index)

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -18,6 +18,8 @@ from math import copysign
 from numbers import Number
 from typing import Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 from rich.progress import track  # optional progress bars
+from rich.console import Console
+from contextlib import nullcontext  # optional status for param combos
 
 import numpy as np
 import pandas as pd
@@ -1332,12 +1334,15 @@ class Backtest:
             grid_frac = (1 if max_tries is None else
                          max_tries if 0 < max_tries <= 1 else
                          max_tries / _grid_size())
-            param_combos = [dict(params)  # back to dict so it pickles
-                            for params in (AttrDict(params)
-                                           for params in product(*(zip(repeat(k), _tuple(v))
-                                                                   for k, v in kwargs.items())))
-                            if constraint(params)  # type: ignore
-                            and rand() <= grid_frac]
+
+            with Console().status("Calculating parameter combinations...") if show_progress else nullcontext():
+                param_combos = [dict(params)  # back to dict so it pickles
+                                for params in (AttrDict(params)
+                                            for params in product(*(zip(repeat(k), _tuple(v))
+                                                                    for k, v in kwargs.items())))
+                                if constraint(params)  # type: ignore
+                                and rand() <= grid_frac]
+
             if not param_combos:
                 raise ValueError('No admissible parameter combinations to test')
 

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1260,7 +1260,9 @@ class Backtest:
         [plotting tools].
 
         If `show_progress` is True, display and update a Rich progress bar
-        displaying optimization status across iterations.
+        displaying optimization status across iterations (only if multiprocessing
+        if off). If multiprocessing is enabled (your start method is "fork"), 
+        a status icon is displayed instead of the progress bar.
 
         [OptimizeResult]: \
             https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.OptimizeResult.html

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1158,7 +1158,7 @@ class Backtest:
         with np.errstate(invalid='ignore'):
 
             data_iter = range(start, len(self._data))
-            if show_progress: data_iter = track(data_iter)
+            if show_progress: data_iter = track(data_iter, description="Backtesting...")
 
             for i in data_iter:
                 # Prepare data and indicators for `next` call
@@ -1379,7 +1379,7 @@ class Backtest:
 
                         # Optional Rich progress bar
                         tqdm_iter = _tqdm(as_completed(futures), total=len(futures), desc='Backtest.optimize')
-                        if show_progress: tqdm_iter = track(tqdm_iter)
+                        if show_progress: tqdm_iter = track(tqdm_iter, description="Optimizing...")
 
                         for future in tqdm_iter:
                             batch_index, values = future.result()
@@ -1392,7 +1392,7 @@ class Backtest:
 
                     # Optional Rich progress bar
                     tqdm_iter = _tqdm(range(len(param_batches)))
-                    if show_progress: tqdm_iter = track(tqdm_iter)
+                    if show_progress: tqdm_iter = track(tqdm_iter, description="Optimizing...")
 
                     for batch_index in tqdm_iter:
                         _, values = Backtest._mp_task(backtest_uuid, batch_index)


### PR DESCRIPTION
Some strategies are quite data/indicator heavy, especially when optimizing. I added optional `show_progress` boolean parameters to the `self.run` and `self.optimize` functions (default `False`) in their correct places, such that if they are passed in as `True` by the user, a visually-appealing Rich [progress bar](https://rich.readthedocs.io/en/stable/progress.html) is displayed in the console.

When backtesting, the progress bar represents the position within the dataset. When optimizing, the tracker wraps `_tqdm` in both the `'fork'` multiprocessing start method and the `'posix'` non-multiprocessing method.