### PR TITLE
Fix broken TA-Lib documentation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
                        <p><b>Technical indicator library agnostic</b></p>
                        <p>
                            Compatible with any sensible technical analysis library, such as
-                           <a href="https://mrjbq7.github.io/ta-lib/" class="nobr"><cite>TA-Lib</cite></a> or
+                           <a href="https://ta-lib.github.io/ta-lib-python/" class="nobr"><cite>TA-Lib</cite></a> or
                            <a href="https://tulipindicators.org/"><cite>Tulip</cite></a>.
                        </p>
                    </div>


### PR DESCRIPTION
Fixes https://github.com/kernc/backtesting.py/issues/984

Replaced old/broken TA-Lib link with new working one.