### PR TITLE
BUG: trying to round none / string(tag) / Boolean (is_contingent)

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -405,17 +405,19 @@ class Order:
             setattr(self, f'_{self.__class__.__qualname__}__{k}', v)
         return self
 
+    
     def __repr__(self):
-        return '<Order {}>'.format(', '.join(f'{param}={round(value, 5)}'
+        return '<Order {}>'.format(', '.join(f'{param}={value}'
                                              for param, value in (
-                                                 ('size', self.__size),
-                                                 ('limit', self.__limit_price),
-                                                 ('stop', self.__stop_price),
-                                                 ('sl', self.__sl_price),
-                                                 ('tp', self.__tp_price),
+                                                 ('size', round(self.__size,5)),
+                                                 ('limit', round(self.__limit_price,5) if self.__limit_price is not None else None),
+                                                 ('stop', round(self.__stop_price,5) if self.__stop_price is not None else None),
+                                                 ('sl', round(self.__sl_price,5) if self.__sl_price is not None else None),
+                                                 ('tp', round(self.__tp_price,0) if self.__tp_price is not None else None),
                                                  ('contingent', self.is_contingent),
                                                  ('tag', self.__tag),
                                              ) if value is not None))
+
 
     def cancel(self):
         """Cancel the order."""


### PR DESCRIPTION
BUG: Fix attempting to round none / string(tag) / Boolean (is_contingent) in backtesting.py:408

Optional float values(limit, stop, sl, tp) can be float | None. Testing for none to not pass it to round()
Boolean values (is_contingent) shouldnt be rounded.
Str values (tag) shouldn't be rounded.

See:
[A fix for Comment](https://github.com/kernc/backtesting.py/pull/200#issuecomment-1446897531)