### PR TITLE
Iteration with Single-Step Progression to Improve Flexibility and Adaptability in Algorithmic Strategies

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1663,7 +1663,7 @@ class Backtest:
             show_legend=show_legend,
             open_browser=open_browser)
 
-    def initialize(self, **kwargs):
+    def initialize(self, **kwargs) -> None:
         """
         Initialize the backtest with the given parameters. Keyword arguments are interpreted as strategy parameters.
 
@@ -1692,7 +1692,7 @@ class Backtest:
         self._step_time = start
         self._step_indicator_attrs = indicator_attrs
 
-    def next(self, done:bool|None=None, **kwargs):
+    def next(self, done:bool|None=None, **kwargs) -> None|pd.Series:
         """
         Move the backtest one time step forward and return the results for the current step.
 
@@ -1718,6 +1718,7 @@ class Backtest:
                 pass
 
             # Next tick, a moment before bar close
+            # passing kwargs to be used in the strategy class
             self._step_strategy.next(**kwargs)
             self._step_time += 1
             

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1692,7 +1692,7 @@ class Backtest:
         self._step_time = start
         self._step_indicator_attrs = indicator_attrs
 
-    def next(self):
+    def next(self, done:bool|None=None, **kwargs):
         """
         Move the backtest one time step forward and return the results for the current step.
 
@@ -1718,9 +1718,10 @@ class Backtest:
                 pass
 
             # Next tick, a moment before bar close
-            self._step_strategy.next()
+            self._step_strategy.next(**kwargs)
             self._step_time += 1
-        else:
+            
+        if done==True:
             # Close any remaining open trades so they produce some stats
             for trade in self._step_broker.trades:
                 trade.close()

--- a/backtesting/test/_iteration.py
+++ b/backtesting/test/_iteration.py
@@ -1,0 +1,40 @@
+from backtesting import Backtest
+from backtesting import Strategy
+from backtesting.test import GOOG, SMA
+from backtesting.lib import crossover
+import types
+
+class SmaCross(Strategy):
+    # Define the two MA lags as *class variables*
+    # for later optimization
+    n1 = 10
+    n2 = 20
+    
+    def init(self):
+        # Precompute the two moving averages
+        self.sma1 = self.I(SMA, self.data.Close, self.n1)
+        self.sma2 = self.I(SMA, self.data.Close, self.n2)
+    
+    def next(self):
+        # If sma1 crosses above sma2, close any existing
+        # short trades, and buy the asset
+        if crossover(self.sma1, self.sma2):
+            self.position.close()
+            self.buy()
+
+        # Else, if sma1 crosses below sma2, close any existing
+        # long trades, and sell the asset
+        elif crossover(self.sma2, self.sma1):
+            self.position.close()
+            self.sell()
+
+bt = Backtest(GOOG, SmaCross, cash=10_000, commission=.002)
+# stats = bt.run()
+bt.initialize()
+
+while True:
+    stats = bt.next()
+    if not isinstance(stats, types.NoneType):
+        break
+print(stats)
+bt.plot(results=stats, open_browser=True)

--- a/backtesting/test/_iteration.py
+++ b/backtesting/test/_iteration.py
@@ -3,37 +3,32 @@ from backtesting import Strategy
 from backtesting.test import GOOG, SMA
 from backtesting.lib import crossover
 import types
+import random
+random.seed(0)
 
-class SmaCross(Strategy):
-    # Define the two MA lags as *class variables*
-    # for later optimization
-    n1 = 10
-    n2 = 20
-    
+class TestStrategy(Strategy):
     def init(self):
-        # Precompute the two moving averages
-        self.sma1 = self.I(SMA, self.data.Close, self.n1)
-        self.sma2 = self.I(SMA, self.data.Close, self.n2)
-    
-    def next(self):
-        # If sma1 crosses above sma2, close any existing
-        # short trades, and buy the asset
-        if crossover(self.sma1, self.sma2):
-            self.position.close()
-            self.buy()
+        print("Init", self.equity)
+        
+    def next(self, action=None):
+        # uncomment if you want to test run()
+        # if not action:
+        #     action = random.randint(0, 1)
+        if action!=None:
+            if action == 0:
+                self.buy()
+            elif action == 1:
+                self.position.close()
 
-        # Else, if sma1 crosses below sma2, close any existing
-        # long trades, and sell the asset
-        elif crossover(self.sma2, self.sma1):
-            self.position.close()
-            self.sell()
 
-bt = Backtest(GOOG, SmaCross, cash=10_000, commission=.002)
+bt = Backtest(GOOG, TestStrategy, cash=10_000, commission=.002)
+
 # stats = bt.run()
-bt.initialize()
 
+bt.initialize()
 while True:
-    stats = bt.next()
+    action = random.randint(0, 1)
+    stats = bt.next(action=action)
     if not isinstance(stats, types.NoneType):
         break
 print(stats)


### PR DESCRIPTION
It is possible to split the run() function into two distinct functions, allowing for a single-step iteration on the ticks:
- initialize(): Saves the data and the strategy into a self variable.
- next(): Moves to the next tick in the iteration.

In which scenario do you want to use a next() function instead of a run()?
Using a next() function allows passing any kwargs to the Strategy.next() function. This flexibility enables processing additional information outside the strategy class and injecting it as needed.
However the run function is preserved in order to have the back-compatibility.

For example, one can utilize backtesting.py as an engine to train a reinforcement learning model, requiring an observation and an action at each step.

I've included a test/_iteration.py  with a custom TestStrategy that works with both run and iteration, demonstrating how you can inject any parameters into the next function.
Here an example how I use the single step iteration in order to training an Env with gym and stable-baseline3 library:
https://gist.github.com/IperGiove/325832e30df44639ec78a618b84daf3c
