### PR TITLE
Added Order Fees

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1030,7 +1030,8 @@ class Backtest:
                  margin: float = 1.,
                  trade_on_close=False,
                  hedging=False,
-                 exclusive_orders=False
+                 exclusive_orders=False,
+                 order_fees : float = 0
                  ):
         """
         Initialize a backtest. Requires data and a strategy to test.
@@ -1133,6 +1134,7 @@ class Backtest:
         )
         self._strategy = strategy
         self._results: Optional[pd.Series] = None
+        self.order_fees = order_fees
 
     def run(self, **kwargs) -> pd.Series:
         """
@@ -1238,6 +1240,7 @@ class Backtest:
                 ohlc_data=self._data,
                 risk_free_rate=0.0,
                 strategy_instance=strategy,
+                order_fees=self.order_fees
             )
 
         return self._results


### PR DESCRIPTION
Some brokers don't ask for a fixed commission but instead want a fee for every trade conducted. You can now add an order_fees parameter to the backtesting instance and the fees will show up in a new entry in the result.

if order_fees are not assigned nothing changes

if order_fees are assigned the final report will look like this:
...
Equity Final [$] (without fees)            30228.33435
Equity Final [$]                           30172.33435
...