### PR TITLE
Rounding error in RGB functionality

### DIFF
--- a/backtesting/_plotting.py
+++ b/backtesting/_plotting.py
@@ -88,7 +88,8 @@ def colorgen():
 def lightness(color, lightness=.94):
     rgb = np.array([color.r, color.g, color.b]) / 255
     h, _, s = rgb_to_hls(*rgb)
-    rgb = np.array(hls_to_rgb(h, lightness, s)) * 255.
+    rgb = np.array(hls_to_rgb(h, lightness, s)) * 255
+    rgb = np.rint(rgb)
     return RGB(*rgb)
 
 

--- a/backtesting/_plotting.py
+++ b/backtesting/_plotting.py
@@ -88,8 +88,7 @@ def colorgen():
 def lightness(color, lightness=.94):
     rgb = np.array([color.r, color.g, color.b]) / 255
     h, _, s = rgb_to_hls(*rgb)
-    rgb = np.array(hls_to_rgb(h, lightness, s)) * 255
-    rgb = np.rint(rgb)
+    rgb = (np.array(hls_to_rgb(h, lightness, s)) * 255).astype(int)
     return RGB(*rgb)
 
 


### PR DESCRIPTION
The values before passed to Bokeh were not rounded as integers and were treated as float due to a decimal point. I have added robust checking and enforcement of ints within that function.

Bokeh RGB accepts integers, this error causes issues with serialisation as discussed in  [Issue](https://github.com/bokeh/bokeh/issues/14011#event-13771094080)