### PR TITLE
Implementation for issue #963

### DIFF
--- a/backtesting/lib.py
+++ b/backtesting/lib.py
@@ -470,7 +470,7 @@ class TrailingStrategy(Strategy):
         """
         hi, lo, c_prev = self.data.High, self.data.Low, pd.Series(self.data.Close).shift(1)
         tr = np.max([hi - lo, (c_prev - hi).abs(), (c_prev - lo).abs()], axis=0)
-        atr = pd.Series(tr).rolling(periods).mean().bfill().values
+        atr = pd.Series(tr).ffill().bfill().rolling(periods).mean().values
         self.__atr = atr
 
     def set_trailing_sl(self, n_atr: float = 6):


### PR DESCRIPTION
The issue is fixed by doing a ffill prior to the bfill so that bfill will only be applied to leading NAs, this way makes it possible to compute holding period return (HPR) from p[0] if needed. The ffill and bfill were moved prior to the rolling step to make sure there are no NAs and therefore adding the min_period=1 is not necessary to the rolling function.