### PR TITLE
functools.partial objects do not always have a __module__ attribute, …

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1735,7 +1735,8 @@ class Backtest:
 
 __all__ = [getattr(v, '__name__', k)
            for k, v in globals().items()                        # export
-           if (((callable(v) and getattr(v, '__module__', None) == __name__ or k.isupper()) and                                # or CONSTANTS
+           if (((callable(v) and getattr(v, '__module__', None) == __name__ or  # callables from this module; getattr for Python 3.9; noqa: E501
+                k.isupper()) and  # or CONSTANTS
                not getattr(v, '__name__', k).startswith('_'))]  # neither marked internal
 
 # NOTE: Don't put anything public below here. See above.

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1735,8 +1735,7 @@ class Backtest:
 
 __all__ = [getattr(v, '__name__', k)
            for k, v in globals().items()                        # export
-           if ((callable(v) and v.__module__ == __name__ or     # callables from this module
-                k.isupper()) and                                # or CONSTANTS
+           if (((callable(v) and getattr(v, '__module__', None) == __name__ or k.isupper()) and                                # or CONSTANTS
                not getattr(v, '__name__', k).startswith('_'))]  # neither marked internal
 
 # NOTE: Don't put anything public below here. See above.

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1735,8 +1735,8 @@ class Backtest:
 
 __all__ = [getattr(v, '__name__', k)
            for k, v in globals().items()                        # export
-           if ((callable(v) and getattr(v, '__module__', None) == __name__ or  # callables from this module; getattr for Python 3.9; noqa: E501
-                k.isupper()) and  # or CONSTANTS
+           if ((callable(v) and getattr(v, '__module__', None) == __name__ or  # callables from this module; getattr for Python 3.9; # noqa: E501
+                k.isupper()) and                                # or CONSTANTS
                not getattr(v, '__name__', k).startswith('_'))]  # neither marked internal
 
 # NOTE: Don't put anything public below here. See above.

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1735,7 +1735,7 @@ class Backtest:
 
 __all__ = [getattr(v, '__name__', k)
            for k, v in globals().items()                        # export
-           if (((callable(v) and getattr(v, '__module__', None) == __name__ or  # callables from this module; getattr for Python 3.9; noqa: E501
+           if ((callable(v) and getattr(v, '__module__', None) == __name__ or  # callables from this module; getattr for Python 3.9; noqa: E501
                 k.isupper()) and  # or CONSTANTS
                not getattr(v, '__name__', k).startswith('_'))]  # neither marked internal
 


### PR DESCRIPTION
Fixes https://github.com/kernc/backtesting.py/issues/1232

When working with the latest version of the library, got an error
```
  1752         return plot(
   1753             results=results,
   1754             df=self._data,
   (...)
   1769             show_legend=show_legend,
   1770             open_browser=open_browser)
   1773 # NOTE: Don't put anything public below this __all__ list
   1775 __all__ = [getattr(v, '__name__', k)
   1776            for k, v in globals().items()                        # export
-> 1777            if ((callable(v) and v.__module__ == __name__ or     # callables from this module
   1778                 k.isupper()) and                                # or CONSTANTS
   1779                not getattr(v, '__name__', k).startswith('_'))]  # neither marked internal
   1781 # NOTE: Don't put anything public below here. See above.

AttributeError: 'functools.partial' object has no attribute '__module__'
```
The error is occurring because functools.partial objects do not always have a __module__ attribute, but the backtesting.py library is assuming that all callable objects do.
With the suggested fix, the code started to work.
