### PR TITLE
Added getattr for v.__module__ in lib.py

### DIFF
--- a/backtesting/lib.py
+++ b/backtesting/lib.py
@@ -617,9 +617,9 @@ class MultiBacktest:
 # NOTE: Don't put anything below this __all__ list
 
 __all__ = [getattr(v, '__name__', k)
-           for k, v in globals().items()                        # export
-           if ((callable(v) and v.__module__ == __name__ or     # callables from this module
-                k.isupper()) and                                # or CONSTANTS
-               not getattr(v, '__name__', k).startswith('_'))]  # neither marked internal
+           for k, v in globals().items()                                 # export
+           if ((callable(v) and getattr(v, '__module__') == __name__ or  # callables from this module
+                k.isupper()) and                                         # or CONSTANTS
+               not getattr(v, '__name__', k).startswith('_'))]           # neither marked internal
 
 # NOTE: Don't put anything below here. See above.


### PR DESCRIPTION
I added the getattr function in lib.py in order to avoid the following error when v.module is not present.

'functools.partial' object has no attribute 'module'