### PR TITLE
Introduce NetPnL in Position and Trades.

### DIFF
--- a/backtesting/_stats.py
+++ b/backtesting/_stats.py
@@ -68,6 +68,7 @@ def compute_stats(
             'TP': [t.tp for t in trades],
             'PnL': [t.pl for t in trades],
             'Commissions': [t._commissions for t in trades],
+            'NetPnL': [t.net_pl for t in trades],
             'ReturnPct': [t.pl_pct for t in trades],
             'EntryTime': [t.entry_time for t in trades],
             'ExitTime': [t.exit_time for t in trades],
@@ -87,7 +88,7 @@ def compute_stats(
         commissions = sum(t._commissions for t in trades)
     del trades
 
-    pl = trades_df['PnL']
+    pl = trades_df['NetPnL']
     returns = trades_df['ReturnPct']
     durations = trades_df['Duration']
 

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -370,6 +370,11 @@ class Position:
         return sum(trade.pl for trade in self.__broker.trades)
 
     @property
+    def net_pl(self) -> float:
+        """Net Profit (positive) or loss (negative) of the current position in cash units."""
+        return sum(trade.net_pl for trade in self.__broker.trades)
+
+    @property
     def pl_pct(self) -> float:
         """Profit (positive) or loss (negative) of the current position in percent."""
         total_invested = sum(trade.entry_price * abs(trade.size) for trade in self.__broker.trades)
@@ -674,6 +679,11 @@ class Trade:
         """Trade profit (positive) or loss (negative) in cash units."""
         price = self.__exit_price or self.__broker.last_price
         return self.__size * (price - self.__entry_price)
+
+    @property
+    def net_pl(self):
+        """Trade profit (positive) or loss (negative) after all deductions in cash units."""
+        return self.pl - self._commissions
 
     @property
     def pl_pct(self):

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -347,7 +347,7 @@ class TestBacktest(TestCase):
             sorted(stats['_trades'].columns),
             sorted(['Size', 'EntryBar', 'ExitBar', 'EntryPrice', 'ExitPrice',
                     'SL', 'TP', 'PnL', 'ReturnPct', 'EntryTime', 'ExitTime',
-                    'Duration', 'Tag', 'Commissions',
+                    'Duration', 'Tag', 'Commissions', 'NetPnL',
                     *indicator_columns]))
 
     def test_compute_stats_bordercase(self):


### PR DESCRIPTION
It's a good idea to maintain `pl` and `net_pl` separately. Reasons being

- `commission` is directly deducted from cash once a trade is entered.
- Clients can use `pl` and `net_pl` as per their use case.

If you're on the same page, will make similar changes for `pl_pct`.