### PR TITLE
Introduce flexible height by proportially sizing elements

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1640,7 +1640,8 @@ class Backtest:
             for shmem in shm:
                 shmem.close()
 
-    def plot(self, *, results: pd.Series = None, filename=None, plot_width=None,
+    def plot(self, *, results: pd.Series = None, filename=None,
+             plot_width=None, plot_height=400,
              plot_equity=True, plot_return=False, plot_pl=True,
              plot_volume=True, plot_drawdown=False, plot_trades=True,
              smooth_equity=False, relative_equity=True,
@@ -1661,8 +1662,10 @@ class Backtest:
         current working directory.
 
         `plot_width` is the width of the plot in pixels. If None (default),
-        the plot is made to span 100% of browser width. The height is
-        currently non-adjustable.
+        the plot is made to span 100% of browser width.
+
+        `plot_height` is the height of the main OHLC chart in pixels. Other
+        sections are sized proportionally. Default is 400.
 
         If `plot_equity` is `True`, the resulting plot will contain
         an equity (initial cash plus assets) graph section. This is the same
@@ -1737,6 +1740,7 @@ class Backtest:
             indicators=results._strategy._indicators,
             filename=filename,
             plot_width=plot_width,
+            plot_height=plot_height,
             plot_equity=plot_equity,
             plot_return=plot_return,
             plot_pl=plot_pl,


### PR DESCRIPTION
Let's user set a hardcoded value for the main OHLC chart, will proportially resize other sections.

- Defaults to 400px
- Tested & works in Jupyter Notebooks
- Not tested in a browser

```
bt.plot(
  plot_height=800
)
```

<img width="2006" height="1482" alt="SCR-20250812-iiwj-2" src="https://github.com/user-attachments/assets/1cb131f0-459a-4732-84fc-99183f4dd55a" />
<img width="2010" height="1482" alt="SCR-20250812-iiwj-3" src="https://github.com/user-attachments/assets/277b4558-0f3c-4e72-9b84-173fa84783a4" />