### PR TITLE
Include the number of long and short trades in the output report 

### DIFF
--- a/backtesting/_stats.py
+++ b/backtesting/_stats.py
@@ -175,11 +175,11 @@ def compute_stats(
     s.loc['# Long Trades'] = n_long_trades = len(trades_df.loc[trades_df['IsLong']])
     long_trades_df = trades_df.loc[trades_df['IsLong']]
     win_long_rate = np.nan if not n_long_trades else (long_trades_df['PnL'] > 0).mean()
-    s.loc['Win Long Rate [%]'] = win_long_rate * 100
+    s.loc['Win Rate Longs [%]'] = win_long_rate * 100
     s.loc['# Short Trades'] = n_short_trades = len(trades_df.loc[trades_df['IsShort']])
     short_trades_df = trades_df.loc[trades_df['IsShort']]
     win_short_rate = np.nan if not n_short_trades else (short_trades_df['PnL'] > 0).mean()
-    s.loc['Win Short Rate [%]'] = win_short_rate * 100
+    s.loc['Win Rate Shorts [%]'] = win_short_rate * 100
     s.loc['Long/Short Ratio'] = np.nan if n_long_trades == 0 or n_short_trades == 0 else (n_long_trades / n_short_trades)
     s.loc['Best Trade [%]'] = returns.max() * 100
     s.loc['Worst Trade [%]'] = returns.min() * 100

--- a/backtesting/_stats.py
+++ b/backtesting/_stats.py
@@ -60,6 +60,8 @@ def compute_stats(
         # Came straight from Backtest.run()
         trades_df = pd.DataFrame({
             'Size': [t.size for t in trades],
+            'IsLong': [t.is_long for t in trades],
+            'IsShort': [t.is_short for t in trades],
             'EntryBar': [t.entry_bar for t in trades],
             'ExitBar': [t.exit_bar for t in trades],
             'EntryPrice': [t.entry_price for t in trades],
@@ -170,6 +172,15 @@ def compute_stats(
     s.loc['# Trades'] = n_trades = len(trades_df)
     win_rate = np.nan if not n_trades else (pl > 0).mean()
     s.loc['Win Rate [%]'] = win_rate * 100
+    s.loc['# Long Trades'] = n_long_trades = len(trades_df.loc[trades_df['IsLong']])
+    long_trades_df = trades_df.loc[trades_df['IsLong']]
+    win_long_rate = np.nan if not n_long_trades else (long_trades_df['PnL'] > 0).mean()
+    s.loc['Win Long Rate [%]'] = win_long_rate * 100
+    s.loc['# Short Trades'] = n_short_trades = len(trades_df.loc[trades_df['IsShort']])
+    short_trades_df = trades_df.loc[trades_df['IsShort']]
+    win_short_rate = np.nan if not n_short_trades else (short_trades_df['PnL'] > 0).mean()
+    s.loc['Win Short Rate [%]'] = win_short_rate * 100
+    s.loc['Long/Short Ratio'] = np.nan if n_long_trades == 0 or n_short_trades == 0 else (n_long_trades / n_short_trades)
     s.loc['Best Trade [%]'] = returns.max() * 100
     s.loc['Worst Trade [%]'] = returns.min() * 100
     mean_return = geometric_mean(returns)


### PR DESCRIPTION
Fixes #1309 providing more context on explaining the PnL in terms of number of long and short positions. 

Just to give a bit of context why this is so useful, I have a backtesting model iterator that runs each backtest and concatenates all the reports together into a final dataframe which I then export to excel for slicing and dicing the best model. So each of these stats report outputs is a row.

The output report now is the following, for example, in this example I can see that there is a big imbalance or bias towards bulls. It also reveals the hit rate per side and a quick long to shorts ratio:
```
Start                     2025-09-20 00:00...
End                       2025-10-04 10:00...
Duration                     14 days 10:00:00
Exposure Time [%]                    21.61383
Equity Final [$]                    112.95491
Equity Peak [$]                     113.15776
Commissions [$]                      17.94649
Return [%]                           12.95491
Buy & Hold Return [%]                -0.16376
Return (Ann.) [%]                  4059.93722
Volatility (Ann.) [%]               693.21658
CAGR [%]                           2084.97859
Sharpe Ratio                          5.85666
Sortino Ratio                      4496.70859
Calmar Ratio                       1244.74942
Alpha [%]                             13.0004
Beta                                   0.2778
Max. Drawdown [%]                    -3.26165
Avg. Drawdown [%]                    -0.43875
Max. Drawdown Duration        3 days 23:00:00
Avg. Drawdown Duration        0 days 17:00:00
# Trades                                   49
Win Rate [%]                         65.30612
# Long Trades                              48
Win Rate Longs [%]                   64.58333
# Short Trades                              1
Win Rate Shorts [%]                     100.0
Long/Short Ratio                         48.0
Best Trade [%]                        1.95605
Worst Trade [%]                      -0.66365
Avg. Trade [%]                        0.25247
Max. Trade Duration           0 days 01:00:00
Avg. Trade Duration           0 days 01:00:00
Profit Factor                         2.96564
Expectancy [%]                        0.25432
SQN                                   2.96001
Kelly Criterion                       0.43913
_strategy                 KSpotTradingStra...
_equity_curve                             ...
_trades                       Size  IsLong...
dtype: object
```