### PR TITLE
Speed Enhancements

### DIFF
--- a/backtesting/_stats.py
+++ b/backtesting/_stats.py
@@ -97,34 +97,24 @@ def compute_stats(
         resolution = getattr(_period, 'resolution_string', None) or _period.resolution
         return value.ceil(resolution)
 
-    stat_items: list[tuple[str, object]] = []
-    start = index[0]
-    end = index[-1]
-    duration = end - start
-    stat_items.extend([
-        ('Start', start),
-        ('End', end),
-        ('Duration', duration),
-    ])
+    s = dict()
+    s['Start'] = index[0]
+    s['End'] = index[-1]
+    s['Duration'] = s['End'] - s['Start']
 
     have_position = np.repeat(0, len(index))
     for t in trades_df[['EntryBar', 'ExitBar']].itertuples(index=False):
         have_position[t.EntryBar:t.ExitBar + 1] = 1
 
-    exposure_time_pct = have_position.mean() * 100  # In "n bars" time, not index time
-    stat_items.append(('Exposure Time [%]', exposure_time_pct))
-    equity_final = equity[-1]
-    equity_peak = equity.max()
-    stat_items.append(('Equity Final [$]', equity_final))
-    stat_items.append(('Equity Peak [$]', equity_peak))
+    s['Exposure Time [%]'] = have_position.mean() * 100  # In "n bars" time, not index time
+    s['Equity Final [$]'] = equity[-1]
+    s['Equity Peak [$]'] = equity.max()
     if commissions:
-        stat_items.append(('Commissions [$]', commissions))
-    return_pct = (equity_final - equity[0]) / equity[0] * 100
-    stat_items.append(('Return [%]', return_pct))
+        s['Commissions [$]'] = commissions
+    s['Return [%]'] = (equity[-1] - equity[0]) / equity[0] * 100
     first_trading_bar = _indicator_warmup_nbars(strategy_instance)
     c = ohlc_data.Close.values
-    buy_hold_return_pct = (c[-1] - c[first_trading_bar]) / c[first_trading_bar] * 100
-    stat_items.append(('Buy & Hold Return [%]', buy_hold_return_pct))  # long-only return
+    s['Buy & Hold Return [%]'] = (c[-1] - c[first_trading_bar]) / c[first_trading_bar] * 100  # long-only return
 
     gmean_day_return: float = 0
     day_returns = np.array(np.nan)
@@ -147,29 +137,22 @@ def compute_stats(
     # Our annualized return matches `empyrical.annual_return(day_returns)` whereas
     # our risk doesn't; they use the simpler approach below.
     annualized_return = (1 + gmean_day_return)**annual_trading_days - 1
-    return_ann_pct = annualized_return * 100
-    volatility_ann_pct = np.sqrt((day_returns.var(ddof=int(bool(day_returns.shape))) + (1 + gmean_day_return)**2)**annual_trading_days - (1 + gmean_day_return)**(2 * annual_trading_days)) * 100  # noqa: E501
-    stat_items.append(('Return (Ann.) [%]', return_ann_pct))
-    stat_items.append(('Volatility (Ann.) [%]', volatility_ann_pct))
-    # s.loc['Return (Ann.) [%]'] = gmean_day_return * annual_trading_days * 100
-    # s.loc['Risk (Ann.) [%]'] = day_returns.std(ddof=1) * np.sqrt(annual_trading_days) * 100
+    s['Return (Ann.) [%]'] = annualized_return * 100
+    s['Volatility (Ann.) [%]'] = np.sqrt((day_returns.var(ddof=int(bool(day_returns.shape))) + (1 + gmean_day_return)**2)**annual_trading_days - (1 + gmean_day_return)**(2 * annual_trading_days)) * 100  # noqa: E501
+    # d['Return (Ann.) [%]'] = gmean_day_return * annual_trading_days * 100
+    # d['Risk (Ann.) [%]'] = day_returns.std(ddof=1) * np.sqrt(annual_trading_days) * 100
     if is_datetime_index:
-        time_in_years = (duration.days + duration.seconds / 86400) / annual_trading_days
-        cagr_pct = ((equity_final / equity[0])**(1 / time_in_years) - 1) * 100 if time_in_years else np.nan  # noqa: E501
-        stat_items.append(('CAGR [%]', cagr_pct))
+        time_in_years = (s['Duration'].days + s['Duration'].seconds / 86400) / annual_trading_days
+        s['CAGR [%]'] = ((s['Equity Final [$]'] / equity[0])**(1 / time_in_years) - 1) * 100 if time_in_years else np.nan  # noqa: E501
 
     # Our Sharpe mismatches `empyrical.sharpe_ratio()` because they use arithmetic mean return
     # and simple standard deviation
-    sharpe_denom = volatility_ann_pct or np.nan
-    sharpe_ratio = (return_ann_pct - risk_free_rate * 100) / sharpe_denom
-    stat_items.append(('Sharpe Ratio', sharpe_ratio))  # noqa: E501
+    s['Sharpe Ratio'] = (s['Return (Ann.) [%]'] - risk_free_rate * 100) / (s['Volatility (Ann.) [%]'] or np.nan)  # noqa: E501
     # Our Sortino mismatches `empyrical.sortino_ratio()` because they use arithmetic mean return
     with np.errstate(divide='ignore'):
-        sortino_ratio = (annualized_return - risk_free_rate) / (np.sqrt(np.mean(day_returns.clip(-np.inf, 0)**2)) * np.sqrt(annual_trading_days))  # noqa: E501
-    stat_items.append(('Sortino Ratio', sortino_ratio))
+        s['Sortino Ratio'] = (annualized_return - risk_free_rate) / (np.sqrt(np.mean(day_returns.clip(-np.inf, 0)**2)) * np.sqrt(annual_trading_days))  # noqa: E501
     max_dd = -np.nan_to_num(dd.max())
-    calmar_ratio = annualized_return / (-max_dd or np.nan)
-    stat_items.append(('Calmar Ratio', calmar_ratio))
+    s['Calmar Ratio'] = annualized_return / (-max_dd or np.nan)
     equity_log_returns = np.log(equity[1:] / equity[:-1])
     market_log_returns = np.log(c[1:] / c[:-1])
     beta = np.nan
@@ -178,42 +161,31 @@ def compute_stats(
         cov_matrix = np.cov(equity_log_returns, market_log_returns)
         beta = cov_matrix[0, 1] / cov_matrix[1, 1]
     # Jensen CAPM Alpha: can be strongly positive when beta is negative and B&H Return is large
-    alpha_pct = return_pct - risk_free_rate * 100 - beta * (buy_hold_return_pct - risk_free_rate * 100)  # noqa: E501
-    stat_items.append(('Alpha [%]', alpha_pct))
-    stat_items.append(('Beta', beta))
-    stat_items.append(('Max. Drawdown [%]', max_dd * 100))
-    stat_items.append(('Avg. Drawdown [%]', -dd_peaks.mean() * 100))
-    stat_items.append(('Max. Drawdown Duration', _round_timedelta(dd_dur.max())))
-    stat_items.append(('Avg. Drawdown Duration', _round_timedelta(dd_dur.mean())))
-    n_trades = len(trades_df)
-    stat_items.append(('# Trades', n_trades))
+    s['Alpha [%]'] = s['Return [%]'] - risk_free_rate * 100 - beta * (s['Buy & Hold Return [%]'] - risk_free_rate * 100)  # noqa: E501
+    s['Beta'] = beta
+    s['Max. Drawdown [%]'] = max_dd * 100
+    s['Avg. Drawdown [%]'] = -dd_peaks.mean() * 100
+    s['Max. Drawdown Duration'] = _round_timedelta(dd_dur.max())
+    s['Avg. Drawdown Duration'] = _round_timedelta(dd_dur.mean())
+    s['# Trades'] = n_trades = len(trades_df)
     win_rate = np.nan if not n_trades else (pl > 0).mean()
-    stat_items.append(('Win Rate [%]', win_rate * 100))
-    stat_items.append(('Best Trade [%]', returns.max() * 100))
-    stat_items.append(('Worst Trade [%]', returns.min() * 100))
+    s['Win Rate [%]'] = win_rate * 100
+    s['Best Trade [%]'] = returns.max() * 100
+    s['Worst Trade [%]'] = returns.min() * 100
     mean_return = geometric_mean(returns)
-    stat_items.append(('Avg. Trade [%]', mean_return * 100))
-    stat_items.append(('Max. Trade Duration', _round_timedelta(durations.max())))
-    stat_items.append(('Avg. Trade Duration', _round_timedelta(durations.mean())))
-    profit_factor = returns[returns > 0].sum() / (abs(returns[returns < 0].sum()) or np.nan)  # noqa: E501
-    stat_items.append(('Profit Factor', profit_factor))
-    expectancy = returns.mean() * 100
-    stat_items.append(('Expectancy [%]', expectancy))
-    sqn = np.sqrt(n_trades) * pl.mean() / (pl.std() or np.nan)
-    stat_items.append(('SQN', sqn))
-    kelly = win_rate - (1 - win_rate) / (pl[pl > 0].mean() / -pl[pl < 0].mean())
-    stat_items.append(('Kelly Criterion', kelly))
+    s['Avg. Trade [%]'] = mean_return * 100
+    s['Max. Trade Duration'] = _round_timedelta(durations.max())
+    s['Avg. Trade Duration'] = _round_timedelta(durations.mean())
+    s['Profit Factor'] = returns[returns > 0].sum() / (abs(returns[returns < 0].sum()) or np.nan)  # noqa: E501
+    s['Expectancy [%]'] = returns.mean() * 100
+    s['SQN'] = np.sqrt(n_trades) * pl.mean() / (pl.std() or np.nan)
+    s['Kelly Criterion'] = win_rate - (1 - win_rate) / (pl[pl > 0].mean() / -pl[pl < 0].mean())
 
-    stat_items.extend([
-        ('_strategy', strategy_instance),
-        ('_equity_curve', equity_df),
-        ('_trades', trades_df),
-    ])
+    s['_strategy'] = strategy_instance
+    s['_equity_curve'] = equity_df
+    s['_trades'] = trades_df
 
-    labels, values = zip(*stat_items)
-    s = pd.Series(values, index=labels, dtype=object)
-
-    s = _Stats(s)
+    s = _Stats(s, dtype=object)
     return s
 
 

--- a/backtesting/_stats.py
+++ b/backtesting/_stats.py
@@ -97,24 +97,34 @@ def compute_stats(
         resolution = getattr(_period, 'resolution_string', None) or _period.resolution
         return value.ceil(resolution)
 
-    s = pd.Series(dtype=object)
-    s.loc['Start'] = index[0]
-    s.loc['End'] = index[-1]
-    s.loc['Duration'] = s.End - s.Start
+    stat_items: list[tuple[str, object]] = []
+    start = index[0]
+    end = index[-1]
+    duration = end - start
+    stat_items.extend([
+        ('Start', start),
+        ('End', end),
+        ('Duration', duration),
+    ])
 
     have_position = np.repeat(0, len(index))
     for t in trades_df[['EntryBar', 'ExitBar']].itertuples(index=False):
         have_position[t.EntryBar:t.ExitBar + 1] = 1
 
-    s.loc['Exposure Time [%]'] = have_position.mean() * 100  # In "n bars" time, not index time
-    s.loc['Equity Final [$]'] = equity[-1]
-    s.loc['Equity Peak [$]'] = equity.max()
+    exposure_time_pct = have_position.mean() * 100  # In "n bars" time, not index time
+    stat_items.append(('Exposure Time [%]', exposure_time_pct))
+    equity_final = equity[-1]
+    equity_peak = equity.max()
+    stat_items.append(('Equity Final [$]', equity_final))
+    stat_items.append(('Equity Peak [$]', equity_peak))
     if commissions:
-        s.loc['Commissions [$]'] = commissions
-    s.loc['Return [%]'] = (equity[-1] - equity[0]) / equity[0] * 100
+        stat_items.append(('Commissions [$]', commissions))
+    return_pct = (equity_final - equity[0]) / equity[0] * 100
+    stat_items.append(('Return [%]', return_pct))
     first_trading_bar = _indicator_warmup_nbars(strategy_instance)
     c = ohlc_data.Close.values
-    s.loc['Buy & Hold Return [%]'] = (c[-1] - c[first_trading_bar]) / c[first_trading_bar] * 100  # long-only return
+    buy_hold_return_pct = (c[-1] - c[first_trading_bar]) / c[first_trading_bar] * 100
+    stat_items.append(('Buy & Hold Return [%]', buy_hold_return_pct))  # long-only return
 
     gmean_day_return: float = 0
     day_returns = np.array(np.nan)
@@ -137,22 +147,29 @@ def compute_stats(
     # Our annualized return matches `empyrical.annual_return(day_returns)` whereas
     # our risk doesn't; they use the simpler approach below.
     annualized_return = (1 + gmean_day_return)**annual_trading_days - 1
-    s.loc['Return (Ann.) [%]'] = annualized_return * 100
-    s.loc['Volatility (Ann.) [%]'] = np.sqrt((day_returns.var(ddof=int(bool(day_returns.shape))) + (1 + gmean_day_return)**2)**annual_trading_days - (1 + gmean_day_return)**(2 * annual_trading_days)) * 100  # noqa: E501
+    return_ann_pct = annualized_return * 100
+    volatility_ann_pct = np.sqrt((day_returns.var(ddof=int(bool(day_returns.shape))) + (1 + gmean_day_return)**2)**annual_trading_days - (1 + gmean_day_return)**(2 * annual_trading_days)) * 100  # noqa: E501
+    stat_items.append(('Return (Ann.) [%]', return_ann_pct))
+    stat_items.append(('Volatility (Ann.) [%]', volatility_ann_pct))
     # s.loc['Return (Ann.) [%]'] = gmean_day_return * annual_trading_days * 100
     # s.loc['Risk (Ann.) [%]'] = day_returns.std(ddof=1) * np.sqrt(annual_trading_days) * 100
     if is_datetime_index:
-        time_in_years = (s.loc['Duration'].days + s.loc['Duration'].seconds / 86400) / annual_trading_days
-        s.loc['CAGR [%]'] = ((s.loc['Equity Final [$]'] / equity[0])**(1 / time_in_years) - 1) * 100 if time_in_years else np.nan  # noqa: E501
+        time_in_years = (duration.days + duration.seconds / 86400) / annual_trading_days
+        cagr_pct = ((equity_final / equity[0])**(1 / time_in_years) - 1) * 100 if time_in_years else np.nan  # noqa: E501
+        stat_items.append(('CAGR [%]', cagr_pct))
 
     # Our Sharpe mismatches `empyrical.sharpe_ratio()` because they use arithmetic mean return
     # and simple standard deviation
-    s.loc['Sharpe Ratio'] = (s.loc['Return (Ann.) [%]'] - risk_free_rate * 100) / (s.loc['Volatility (Ann.) [%]'] or np.nan)  # noqa: E501
+    sharpe_denom = volatility_ann_pct or np.nan
+    sharpe_ratio = (return_ann_pct - risk_free_rate * 100) / sharpe_denom
+    stat_items.append(('Sharpe Ratio', sharpe_ratio))  # noqa: E501
     # Our Sortino mismatches `empyrical.sortino_ratio()` because they use arithmetic mean return
     with np.errstate(divide='ignore'):
-        s.loc['Sortino Ratio'] = (annualized_return - risk_free_rate) / (np.sqrt(np.mean(day_returns.clip(-np.inf, 0)**2)) * np.sqrt(annual_trading_days))  # noqa: E501
+        sortino_ratio = (annualized_return - risk_free_rate) / (np.sqrt(np.mean(day_returns.clip(-np.inf, 0)**2)) * np.sqrt(annual_trading_days))  # noqa: E501
+    stat_items.append(('Sortino Ratio', sortino_ratio))
     max_dd = -np.nan_to_num(dd.max())
-    s.loc['Calmar Ratio'] = annualized_return / (-max_dd or np.nan)
+    calmar_ratio = annualized_return / (-max_dd or np.nan)
+    stat_items.append(('Calmar Ratio', calmar_ratio))
     equity_log_returns = np.log(equity[1:] / equity[:-1])
     market_log_returns = np.log(c[1:] / c[:-1])
     beta = np.nan
@@ -161,29 +178,40 @@ def compute_stats(
         cov_matrix = np.cov(equity_log_returns, market_log_returns)
         beta = cov_matrix[0, 1] / cov_matrix[1, 1]
     # Jensen CAPM Alpha: can be strongly positive when beta is negative and B&H Return is large
-    s.loc['Alpha [%]'] = s.loc['Return [%]'] - risk_free_rate * 100 - beta * (s.loc['Buy & Hold Return [%]'] - risk_free_rate * 100)  # noqa: E501
-    s.loc['Beta'] = beta
-    s.loc['Max. Drawdown [%]'] = max_dd * 100
-    s.loc['Avg. Drawdown [%]'] = -dd_peaks.mean() * 100
-    s.loc['Max. Drawdown Duration'] = _round_timedelta(dd_dur.max())
-    s.loc['Avg. Drawdown Duration'] = _round_timedelta(dd_dur.mean())
-    s.loc['# Trades'] = n_trades = len(trades_df)
+    alpha_pct = return_pct - risk_free_rate * 100 - beta * (buy_hold_return_pct - risk_free_rate * 100)  # noqa: E501
+    stat_items.append(('Alpha [%]', alpha_pct))
+    stat_items.append(('Beta', beta))
+    stat_items.append(('Max. Drawdown [%]', max_dd * 100))
+    stat_items.append(('Avg. Drawdown [%]', -dd_peaks.mean() * 100))
+    stat_items.append(('Max. Drawdown Duration', _round_timedelta(dd_dur.max())))
+    stat_items.append(('Avg. Drawdown Duration', _round_timedelta(dd_dur.mean())))
+    n_trades = len(trades_df)
+    stat_items.append(('# Trades', n_trades))
     win_rate = np.nan if not n_trades else (pl > 0).mean()
-    s.loc['Win Rate [%]'] = win_rate * 100
-    s.loc['Best Trade [%]'] = returns.max() * 100
-    s.loc['Worst Trade [%]'] = returns.min() * 100
+    stat_items.append(('Win Rate [%]', win_rate * 100))
+    stat_items.append(('Best Trade [%]', returns.max() * 100))
+    stat_items.append(('Worst Trade [%]', returns.min() * 100))
     mean_return = geometric_mean(returns)
-    s.loc['Avg. Trade [%]'] = mean_return * 100
-    s.loc['Max. Trade Duration'] = _round_timedelta(durations.max())
-    s.loc['Avg. Trade Duration'] = _round_timedelta(durations.mean())
-    s.loc['Profit Factor'] = returns[returns > 0].sum() / (abs(returns[returns < 0].sum()) or np.nan)  # noqa: E501
-    s.loc['Expectancy [%]'] = returns.mean() * 100
-    s.loc['SQN'] = np.sqrt(n_trades) * pl.mean() / (pl.std() or np.nan)
-    s.loc['Kelly Criterion'] = win_rate - (1 - win_rate) / (pl[pl > 0].mean() / -pl[pl < 0].mean())
+    stat_items.append(('Avg. Trade [%]', mean_return * 100))
+    stat_items.append(('Max. Trade Duration', _round_timedelta(durations.max())))
+    stat_items.append(('Avg. Trade Duration', _round_timedelta(durations.mean())))
+    profit_factor = returns[returns > 0].sum() / (abs(returns[returns < 0].sum()) or np.nan)  # noqa: E501
+    stat_items.append(('Profit Factor', profit_factor))
+    expectancy = returns.mean() * 100
+    stat_items.append(('Expectancy [%]', expectancy))
+    sqn = np.sqrt(n_trades) * pl.mean() / (pl.std() or np.nan)
+    stat_items.append(('SQN', sqn))
+    kelly = win_rate - (1 - win_rate) / (pl[pl > 0].mean() / -pl[pl < 0].mean())
+    stat_items.append(('Kelly Criterion', kelly))
 
-    s.loc['_strategy'] = strategy_instance
-    s.loc['_equity_curve'] = equity_df
-    s.loc['_trades'] = trades_df
+    stat_items.extend([
+        ('_strategy', strategy_instance),
+        ('_equity_curve', equity_df),
+        ('_trades', trades_df),
+    ])
+
+    labels, values = zip(*stat_items)
+    s = pd.Series(values, index=labels, dtype=object)
 
     s = _Stats(s)
     return s

--- a/backtesting/_util.py
+++ b/backtesting/_util.py
@@ -216,7 +216,7 @@ class _Data:
             arr = self.__cache[key] = cast(_Array, self.__arrays[key][:self.__len])
         return arr
 
-    def current_value(self, key: str):
+    def _current_value(self, key: str):
         if self.__len <= 0:
             raise IndexError("No data available")
         return self.__arrays[key][self.__len - 1]

--- a/backtesting/_util.py
+++ b/backtesting/_util.py
@@ -216,6 +216,11 @@ class _Data:
             arr = self.__cache[key] = cast(_Array, self.__arrays[key][:self.__len])
         return arr
 
+    def current_value(self, key: str):
+        if self.__len <= 0:
+            raise IndexError("No data available")
+        return self.__arrays[key][self.__len - 1]
+
     @property
     def Open(self) -> _Array:
         return self.__get_array('Open')

--- a/backtesting/_util.py
+++ b/backtesting/_util.py
@@ -217,8 +217,8 @@ class _Data:
         return arr
 
     def _current_value(self, key: str):
-        if self.__len <= 0:
-            raise IndexError("No data available")
+        # Known fast path to avoid needless __get_array reslicing
+        assert self.__len >= 0, self
         return self.__arrays[key][self.__len - 1]
 
     @property

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -13,7 +13,7 @@ import warnings
 from abc import ABCMeta, abstractmethod
 from copy import copy
 from difflib import get_close_matches
-from functools import lru_cache, partial
+from functools import cached_property, lru_cache, partial
 from itertools import chain, product, repeat
 from math import copysign
 from numbers import Number
@@ -344,8 +344,6 @@ class Position:
     @property
     def size(self) -> float:
         """Position size in units of asset. Negative if position is short."""
-        if self.__broker._trade_sums_dirty:
-            self.__broker._recalculate_trade_sums()
         return self.__broker._open_trade_size_sum
 
     @property
@@ -356,8 +354,6 @@ class Position:
     @property
     def pl_pct(self) -> float:
         """Profit (positive) or loss (negative) of the current position in percent."""
-        if self.__broker._trade_sums_dirty:
-            self.__broker._recalculate_trade_sums()
         total_invested = self.__broker._open_trade_entry_abs_value_sum
         return (self.pl / total_invested) * 100 if total_invested else 0
 
@@ -758,10 +754,6 @@ class _Broker:
         self.trades: List[Trade] = []
         self.position = Position(self)
         self.closed_trades: List[Trade] = []
-        self._trade_sums_dirty = True
-        self._open_trade_size_sum = 0
-        self._open_trade_entry_value_sum = 0.0
-        self._open_trade_entry_abs_value_sum = 0.0
 
     def _commission_func(self, order_size, price):
         return self._commission_fixed + abs(order_size) * price * self._commission_relative
@@ -819,23 +811,25 @@ class _Broker:
 
         return order
 
-    def _mark_trade_sums_dirty(self) -> None:
-        self._trade_sums_dirty = True
+    @cached_property
+    def _open_trade_size_sum(self) -> int:
+        return sum(int(trade.size) for trade in self.trades)
 
-    def _recalculate_trade_sums(self) -> None:
-        self._open_trade_size_sum = sum(int(trade.size) for trade in self.trades)
-        self._open_trade_entry_value_sum = sum(
-            trade.size * trade.entry_price for trade in self.trades
-        )
-        self._open_trade_entry_abs_value_sum = sum(
-            abs(trade.size) * trade.entry_price for trade in self.trades
-        )
-        self._trade_sums_dirty = False
+    @cached_property
+    def _open_trade_entry_value_sum(self) -> float:
+        return sum(trade.size * trade.entry_price for trade in self.trades)
+
+    @cached_property
+    def _open_trade_entry_abs_value_sum(self) -> float:
+        return sum(abs(trade.size) * trade.entry_price for trade in self.trades)
+
+    def _clear_trade_caches(self) -> None:
+        self.__dict__.pop('_open_trade_size_sum', None)
+        self.__dict__.pop('_open_trade_entry_value_sum', None)
+        self.__dict__.pop('_open_trade_entry_abs_value_sum', None)
 
     @property
     def unrealized_pl(self) -> float:
-        if self._trade_sums_dirty:
-            self._recalculate_trade_sums()
         if not self.trades:
             return 0.0
         current_price = float(self._data._current_value("Close"))
@@ -1086,7 +1080,7 @@ class _Broker:
     def _reduce_trade(self, trade: Trade, price: float, size: float, time_index: int):
         assert trade.size * size < 0
         assert abs(trade.size) >= abs(size)
-        self._mark_trade_sums_dirty()
+        self._clear_trade_caches()
 
         size_left = trade.size + size
         assert size_left * trade.size >= 0
@@ -1107,7 +1101,7 @@ class _Broker:
         self._close_trade(close_trade, price, time_index)
 
     def _close_trade(self, trade: Trade, price: float, time_index: int):
-        self._mark_trade_sums_dirty()
+        self._clear_trade_caches()
         self.trades.remove(trade)
         if trade._sl_order:
             self.orders.remove(trade._sl_order)
@@ -1131,7 +1125,7 @@ class _Broker:
         self.trades.append(trade)
         # Apply broker commission at trade open
         self._cash -= self._commission(size, price)
-        self._mark_trade_sums_dirty()
+        self._clear_trade_caches()
         # Create SL/TP (bracket) orders.
         if tp:
             trade.tp = tp

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -838,7 +838,7 @@ class _Broker:
             self._recalculate_trade_sums()
         if not self.trades:
             return 0.0
-        current_price = float(self._data.current_value("Close"))
+        current_price = float(self._data._current_value("Close"))
         return current_price * self._open_trade_size_sum - self._open_trade_entry_value_sum
 
     @property
@@ -882,9 +882,9 @@ class _Broker:
 
     def _process_orders(self):
         data = self._data
-        open_price = data.current_value("Open")
-        high_price = data.current_value("High")
-        low_price = data.current_value("Low")
+        open_price = data._current_value("Open")
+        high_price = data._current_value("High")
+        low_price = data._current_value("Low")
         reprocess_orders = False
 
         # Process orders

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -344,17 +344,21 @@ class Position:
     @property
     def size(self) -> float:
         """Position size in units of asset. Negative if position is short."""
-        return sum(trade.size for trade in self.__broker.trades)
+        if self.__broker._trade_sums_dirty:
+            self.__broker._recalculate_trade_sums()
+        return self.__broker._open_trade_size_sum
 
     @property
     def pl(self) -> float:
         """Profit (positive) or loss (negative) of the current position in cash units."""
-        return sum(trade.pl for trade in self.__broker.trades)
+        return self.__broker.unrealized_pl
 
     @property
     def pl_pct(self) -> float:
         """Profit (positive) or loss (negative) of the current position in percent."""
-        total_invested = sum(trade.entry_price * abs(trade.size) for trade in self.__broker.trades)
+        if self.__broker._trade_sums_dirty:
+            self.__broker._recalculate_trade_sums()
+        total_invested = self.__broker._open_trade_entry_abs_value_sum
         return (self.pl / total_invested) * 100 if total_invested else 0
 
     @property
@@ -754,6 +758,10 @@ class _Broker:
         self.trades: List[Trade] = []
         self.position = Position(self)
         self.closed_trades: List[Trade] = []
+        self._trade_sums_dirty = True
+        self._open_trade_size_sum = 0
+        self._open_trade_entry_value_sum = 0.0
+        self._open_trade_entry_abs_value_sum = 0.0
 
     def _commission_func(self, order_size, price):
         return self._commission_fixed + abs(order_size) * price * self._commission_relative
@@ -811,6 +819,28 @@ class _Broker:
 
         return order
 
+    def _mark_trade_sums_dirty(self) -> None:
+        self._trade_sums_dirty = True
+
+    def _recalculate_trade_sums(self) -> None:
+        self._open_trade_size_sum = sum(int(trade.size) for trade in self.trades)
+        self._open_trade_entry_value_sum = sum(
+            trade.size * trade.entry_price for trade in self.trades
+        )
+        self._open_trade_entry_abs_value_sum = sum(
+            abs(trade.size) * trade.entry_price for trade in self.trades
+        )
+        self._trade_sums_dirty = False
+
+    @property
+    def unrealized_pl(self) -> float:
+        if self._trade_sums_dirty:
+            self._recalculate_trade_sums()
+        if not self.trades:
+            return 0.0
+        current_price = float(self._data.current_value("Close"))
+        return current_price * self._open_trade_size_sum - self._open_trade_entry_value_sum
+
     @property
     def last_price(self) -> float:
         """ Price at the last (current) close. """
@@ -825,7 +855,7 @@ class _Broker:
 
     @property
     def equity(self) -> float:
-        return self._cash + sum(trade.pl for trade in self.trades)
+        return self._cash + self.unrealized_pl
 
     @property
     def margin_available(self) -> float:
@@ -1058,6 +1088,7 @@ class _Broker:
     def _reduce_trade(self, trade: Trade, price: float, size: float, time_index: int):
         assert trade.size * size < 0
         assert abs(trade.size) >= abs(size)
+        self._mark_trade_sums_dirty()
 
         size_left = trade.size + size
         assert size_left * trade.size >= 0
@@ -1078,6 +1109,7 @@ class _Broker:
         self._close_trade(close_trade, price, time_index)
 
     def _close_trade(self, trade: Trade, price: float, time_index: int):
+        self._mark_trade_sums_dirty()
         self.trades.remove(trade)
         if trade._sl_order:
             self.orders.remove(trade._sl_order)
@@ -1101,6 +1133,7 @@ class _Broker:
         self.trades.append(trade)
         # Apply broker commission at trade open
         self._cash -= self._commission(size, price)
+        self._mark_trade_sums_dirty()
         # Create SL/TP (bracket) orders.
         if tp:
             trade.tp = tp

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -824,7 +824,7 @@ class _Broker:
         return (self.last_price * self._position_size -
                 sum(trade.size * trade.entry_price for trade in self.trades))
 
-    def _trades_cache_clear(self) -> None:
+    def _trades_cache_clear(self):
         self.__dict__.pop(self.__class__._position_size.func.__name__, None)
         self.__dict__.pop(self.__class__._position_initial_value.func.__name__, None)
         self.__dict__.pop(self.__class__._position_unrealized_pl.func.__name__, None)

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -838,7 +838,7 @@ class _Broker:
     @property
     def last_price(self) -> float:
         """ Price at the last (current) close. """
-        return self._data.Close[-1]
+        return self._data._current_value('Close')
 
     def _adjusted_price(self, size=None, price=None) -> float:
         """
@@ -869,7 +869,7 @@ class _Broker:
         if equity <= 0:
             assert self.margin_available <= 0
             for trade in self.trades:
-                self._close_trade(trade, self._data.Close[-1], i)
+                self._close_trade(trade, self.last_price, i)
             self._cash = 0
             self._equity[i:] = 0
             raise _OutOfMoneyError

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -344,17 +344,17 @@ class Position:
     @property
     def size(self) -> float:
         """Position size in units of asset. Negative if position is short."""
-        return self.__broker._open_trade_size_sum
+        return self.__broker._position_size
 
     @property
     def pl(self) -> float:
         """Profit (positive) or loss (negative) of the current position in cash units."""
-        return self.__broker.unrealized_pl
+        return self.__broker._position_unrealized_pl
 
     @property
     def pl_pct(self) -> float:
         """Profit (positive) or loss (negative) of the current position in percent."""
-        total_invested = self.__broker._open_trade_entry_abs_value_sum
+        total_invested = self.__broker._position_initial_value
         return (self.pl / total_invested) * 100 if total_invested else 0
 
     @property
@@ -812,28 +812,22 @@ class _Broker:
         return order
 
     @cached_property
-    def _open_trade_size_sum(self) -> int:
+    def _position_size(self) -> int:
         return sum(int(trade.size) for trade in self.trades)
 
     @cached_property
-    def _open_trade_entry_value_sum(self) -> float:
-        return sum(trade.size * trade.entry_price for trade in self.trades)
-
-    @cached_property
-    def _open_trade_entry_abs_value_sum(self) -> float:
+    def _position_initial_value(self) -> float:
         return sum(abs(trade.size) * trade.entry_price for trade in self.trades)
 
-    def _clear_trade_caches(self) -> None:
-        self.__dict__.pop('_open_trade_size_sum', None)
-        self.__dict__.pop('_open_trade_entry_value_sum', None)
-        self.__dict__.pop('_open_trade_entry_abs_value_sum', None)
+    @cached_property
+    def _position_unrealized_pl(self) -> float:
+        return (self.last_price * self._position_size -
+                sum(trade.size * trade.entry_price for trade in self.trades))
 
-    @property
-    def unrealized_pl(self) -> float:
-        if not self.trades:
-            return 0.0
-        current_price = float(self._data._current_value("Close"))
-        return current_price * self._open_trade_size_sum - self._open_trade_entry_value_sum
+    def _trades_cache_clear(self) -> None:
+        self.__dict__.pop(self.__class__._position_size.func.__name__, None)
+        self.__dict__.pop(self.__class__._position_initial_value.func.__name__, None)
+        self.__dict__.pop(self.__class__._position_unrealized_pl.func.__name__, None)
 
     @property
     def last_price(self) -> float:
@@ -849,7 +843,7 @@ class _Broker:
 
     @property
     def equity(self) -> float:
-        return self._cash + self.unrealized_pl
+        return self._cash + self._position_unrealized_pl
 
     @property
     def margin_available(self) -> float:
@@ -858,6 +852,9 @@ class _Broker:
         return max(0, self.equity - margin_used)
 
     def next(self):
+        # Reset cached value here due to price change on every bar
+        self.__dict__.pop(self.__class__._position_unrealized_pl.func.__name__, None)
+
         i = self._i = len(self._data) - 1
         self._process_orders()
 
@@ -1054,7 +1051,7 @@ class _Broker:
     def _reduce_trade(self, trade: Trade, price: float, size: float, time_index: int):
         assert trade.size * size < 0
         assert abs(trade.size) >= abs(size)
-        self._clear_trade_caches()
+        self._trades_cache_clear()
 
         size_left = trade.size + size
         assert size_left * trade.size >= 0
@@ -1075,7 +1072,7 @@ class _Broker:
         self._close_trade(close_trade, price, time_index)
 
     def _close_trade(self, trade: Trade, price: float, time_index: int):
-        self._clear_trade_caches()
+        self._trades_cache_clear()
         self.trades.remove(trade)
         if trade._sl_order:
             self.orders.remove(trade._sl_order)
@@ -1097,9 +1094,9 @@ class _Broker:
                     sl: Optional[float], tp: Optional[float], time_index: int, tag):
         trade = Trade(self, size, price, time_index, tag)
         self.trades.append(trade)
+        self._trades_cache_clear()
         # Apply broker commission at trade open
         self._cash -= self._commission(size, price)
-        self._clear_trade_caches()
         # Create SL/TP (bracket) orders.
         if tp:
             trade.tp = tp

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -889,9 +889,7 @@ class _Broker:
             # Check if stop condition was hit
             stop_price = order.stop
             if stop_price:
-                is_stop_hit = (
-                    high >= stop_price if order.is_long else low <= stop_price
-                )
+                is_stop_hit = ((high >= stop_price) if order.is_long else (low <= stop_price))
                 if not is_stop_hit:
                     continue
 
@@ -902,9 +900,7 @@ class _Broker:
             # Determine purchase price.
             # Check if limit order can be filled.
             if order.limit:
-                is_limit_hit = (
-                    low <= order.limit if order.is_long else high >= order.limit
-                )
+                is_limit_hit = low <= order.limit if order.is_long else high >= order.limit
                 # When stop and limit are hit within the same bar, we pessimistically
                 # assume limit was hit before the stop (i.e. "before it counts")
                 is_limit_hit_before_stop = (is_limit_hit and
@@ -915,20 +911,14 @@ class _Broker:
                     continue
 
                 # stop_price, if set, was hit within this bar
-                price = (
-                    min(stop_price or open, order.limit)
-                    if order.is_long
-                    else max(stop_price or open, order.limit)
-                )
+                price = (min(stop_price or open, order.limit)
+                         if order.is_long else
+                         max(stop_price or open, order.limit))
             else:
                 # Market-if-touched / market order
                 # Contingent orders always on next open
                 prev_close = data.Close[-2]
-                price = (
-                    prev_close
-                    if self._trade_on_close and not order.is_contingent
-                    else open
-                )
+                price = prev_close if self._trade_on_close and not order.is_contingent else open
                 if stop_price:
                     price = max(price, stop_price) if order.is_long else min(price, stop_price)
 
@@ -1039,28 +1029,12 @@ class _Broker:
                         reprocess_orders = True
                     # Order.stop and TP hit within the same bar, but SL wasn't. This case
                     # is not ambiguous, because stop and TP go in the same price direction.
-                    elif (
-                        stop_price
-                        and not order.limit
-                        and order.tp
-                        and (
-                            (
-                                order.is_long
-                                and order.tp <= high
-                                and (order.sl or -np.inf) < low
-                            )
-                            or (
-                                order.is_short
-                                and order.tp >= low
-                                and (order.sl or np.inf) > high
-                            )
-                        )
-                    ):
+                    elif stop_price and not order.limit and order.tp and (
+                            (order.is_long and order.tp <= high and (order.sl or -np.inf) < low) or
+                            (order.is_short and order.tp >= low and (order.sl or np.inf) > high)):
                         reprocess_orders = True
-                    elif (
-                        low <= (order.sl or -np.inf) <= high
-                        or low <= (order.tp or -np.inf) <= high
-                    ):
+                    elif (low <= (order.sl or -np.inf) <= high or
+                          low <= (order.tp or -np.inf) <= high):
                         warnings.warn(
                             f"({data.index[-1]}) A contingent SL/TP order would execute in the "
                             "same bar its parent stop/limit order was turned into a trade. "

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -852,7 +852,9 @@ class _Broker:
 
     def _process_orders(self):
         data = self._data
-        open, high, low = data.Open[-1], data.High[-1], data.Low[-1]
+        open_price = data.current_value("Open")
+        high_price = data.current_value("High")
+        low_price = data.current_value("Low")
         reprocess_orders = False
 
         # Process orders
@@ -865,7 +867,9 @@ class _Broker:
             # Check if stop condition was hit
             stop_price = order.stop
             if stop_price:
-                is_stop_hit = ((high >= stop_price) if order.is_long else (low <= stop_price))
+                is_stop_hit = (
+                    high_price >= stop_price if order.is_long else low_price <= stop_price
+                )
                 if not is_stop_hit:
                     continue
 
@@ -876,7 +880,9 @@ class _Broker:
             # Determine purchase price.
             # Check if limit order can be filled.
             if order.limit:
-                is_limit_hit = low <= order.limit if order.is_long else high >= order.limit
+                is_limit_hit = (
+                    low_price <= order.limit if order.is_long else high_price >= order.limit
+                )
                 # When stop and limit are hit within the same bar, we pessimistically
                 # assume limit was hit before the stop (i.e. "before it counts")
                 is_limit_hit_before_stop = (is_limit_hit and
@@ -887,14 +893,20 @@ class _Broker:
                     continue
 
                 # stop_price, if set, was hit within this bar
-                price = (min(stop_price or open, order.limit)
-                         if order.is_long else
-                         max(stop_price or open, order.limit))
+                price = (
+                    min(stop_price or open_price, order.limit)
+                    if order.is_long
+                    else max(stop_price or open_price, order.limit)
+                )
             else:
                 # Market-if-touched / market order
                 # Contingent orders always on next open
                 prev_close = data.Close[-2]
-                price = prev_close if self._trade_on_close and not order.is_contingent else open
+                price = (
+                    prev_close
+                    if self._trade_on_close and not order.is_contingent
+                    else open_price
+                )
                 if stop_price:
                     price = max(price, stop_price) if order.is_long else min(price, stop_price)
 
@@ -1005,12 +1017,28 @@ class _Broker:
                         reprocess_orders = True
                     # Order.stop and TP hit within the same bar, but SL wasn't. This case
                     # is not ambiguous, because stop and TP go in the same price direction.
-                    elif stop_price and not order.limit and order.tp and (
-                            (order.is_long and order.tp <= high and (order.sl or -np.inf) < low) or
-                            (order.is_short and order.tp >= low and (order.sl or np.inf) > high)):
+                    elif (
+                        stop_price
+                        and not order.limit
+                        and order.tp
+                        and (
+                            (
+                                order.is_long
+                                and order.tp <= high_price
+                                and (order.sl or -np.inf) < low_price
+                            )
+                            or (
+                                order.is_short
+                                and order.tp >= low_price
+                                and (order.sl or np.inf) > high_price
+                            )
+                        )
+                    ):
                         reprocess_orders = True
-                    elif (low <= (order.sl or -np.inf) <= high or
-                          low <= (order.tp or -np.inf) <= high):
+                    elif (
+                        low_price <= (order.sl or -np.inf) <= high_price
+                        or low_price <= (order.tp or -np.inf) <= high_price
+                    ):
                         warnings.warn(
                             f"({data.index[-1]}) A contingent SL/TP order would execute in the "
                             "same bar its parent stop/limit order was turned into a trade. "

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -882,9 +882,7 @@ class _Broker:
 
     def _process_orders(self):
         data = self._data
-        open_price = data._current_value("Open")
-        high_price = data._current_value("High")
-        low_price = data._current_value("Low")
+        open, high, low = data._current_value("Open"), data._current_value("High"), data._current_value("Low")
         reprocess_orders = False
 
         # Process orders
@@ -898,7 +896,7 @@ class _Broker:
             stop_price = order.stop
             if stop_price:
                 is_stop_hit = (
-                    high_price >= stop_price if order.is_long else low_price <= stop_price
+                    high >= stop_price if order.is_long else low <= stop_price
                 )
                 if not is_stop_hit:
                     continue
@@ -911,7 +909,7 @@ class _Broker:
             # Check if limit order can be filled.
             if order.limit:
                 is_limit_hit = (
-                    low_price <= order.limit if order.is_long else high_price >= order.limit
+                    low <= order.limit if order.is_long else high >= order.limit
                 )
                 # When stop and limit are hit within the same bar, we pessimistically
                 # assume limit was hit before the stop (i.e. "before it counts")
@@ -924,9 +922,9 @@ class _Broker:
 
                 # stop_price, if set, was hit within this bar
                 price = (
-                    min(stop_price or open_price, order.limit)
+                    min(stop_price or open, order.limit)
                     if order.is_long
-                    else max(stop_price or open_price, order.limit)
+                    else max(stop_price or open, order.limit)
                 )
             else:
                 # Market-if-touched / market order
@@ -935,7 +933,7 @@ class _Broker:
                 price = (
                     prev_close
                     if self._trade_on_close and not order.is_contingent
-                    else open_price
+                    else open
                 )
                 if stop_price:
                     price = max(price, stop_price) if order.is_long else min(price, stop_price)
@@ -1054,20 +1052,20 @@ class _Broker:
                         and (
                             (
                                 order.is_long
-                                and order.tp <= high_price
-                                and (order.sl or -np.inf) < low_price
+                                and order.tp <= high
+                                and (order.sl or -np.inf) < low
                             )
                             or (
                                 order.is_short
-                                and order.tp >= low_price
-                                and (order.sl or np.inf) > high_price
+                                and order.tp >= low
+                                and (order.sl or np.inf) > high
                             )
                         )
                     ):
                         reprocess_orders = True
                     elif (
-                        low_price <= (order.sl or -np.inf) <= high_price
-                        or low_price <= (order.tp or -np.inf) <= high_price
+                        low <= (order.sl or -np.inf) <= high
+                        or low <= (order.tp or -np.inf) <= high
                     ):
                         warnings.warn(
                             f"({data.index[-1]}) A contingent SL/TP order would execute in the "


### PR DESCRIPTION
I've included here some speed enhancements from my video:
https://youtu.be/LSo4ghiAPvk

Running the SMA strategy from the README on my machine this PR gives a roughly 40% reduction in total runtime for `bt.run`

Tests all pass