### PR TITLE
PERF: Revert multiprocessing start method change introduced in Python 3.14

### DIFF
--- a/backtesting/__init__.py
+++ b/backtesting/__init__.py
@@ -67,12 +67,17 @@ except ImportError:
 
 from . import lib  # noqa: F401
 from ._plotting import set_bokeh_output  # noqa: F401
+from ._util import try_
 from .backtesting import Backtest, Strategy  # noqa: F401
 
 
 # Add overridable backtesting.Pool used for parallel optimization
 def Pool(processes=None, initializer=None, initargs=()):
     import multiprocessing as mp
+    import sys
+    # Revert performance related change in Python>=3.14
+    if sys.platform.startswith('linux') and mp.get_start_method(allow_none=True) != 'fork':
+        try_(lambda: mp.set_start_method('fork'))
     if mp.get_start_method() == 'spawn':
         import warnings
         warnings.warn(

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -1039,10 +1039,13 @@ class TestDocs(TestCase):
     DOCS_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'doc')
 
     @unittest.skipUnless(os.path.isdir(DOCS_DIR), "docs dir doesn't exist")
+    @unittest.skipUnless(sys.platform.startswith('linux'), "test_examples requires mp.start_method=fork")
     def test_examples(self):
+        import backtesting
         examples = glob(os.path.join(self.DOCS_DIR, 'examples', '*.py'))
         self.assertGreaterEqual(len(examples), 4)
-        with chdir(gettempdir()):
+        with chdir(gettempdir()), \
+                patch(backtesting, 'Pool', mp.get_context('fork').Pool):
             for file in examples:
                 with self.subTest(example=os.path.basename(file)):
                     run_path(file)


### PR DESCRIPTION
Refs: https://github.com/python/cpython/issues/84559

Fixes CI failing on `TestDocs.test_examples`:

    ModuleNotFoundError: No module named '<run_path>'