### PR TITLE
Add # Long Trades and # Short Trades to stats output

### DIFF
--- a/backtesting/_stats.py
+++ b/backtesting/_stats.py
@@ -168,6 +168,8 @@ def compute_stats(
     s.loc['Max. Drawdown Duration'] = _round_timedelta(dd_dur.max())
     s.loc['Avg. Drawdown Duration'] = _round_timedelta(dd_dur.mean())
     s.loc['# Trades'] = n_trades = len(trades_df)
+    s.loc['# Long Trades'] = (trades_df['Size'] > 0).sum() if n_trades else 0
+    s.loc['# Short Trades'] = (trades_df['Size'] < 0).sum() if n_trades else 0
     win_rate = np.nan if not n_trades else (pl > 0).mean()
     s.loc['Win Rate [%]'] = win_rate * 100
     s.loc['Best Trade [%]'] = returns.max() * 100


### PR DESCRIPTION
## Summary
Add two new statistics to the backtest results output:
- `# Long Trades`: count of trades with positive size (long positions)
- `# Short Trades`: count of trades with negative size (short positions)

## Example output
```
# Trades                                   23
# Long Trades                              15
# Short Trades                              8
Win Rate [%]                         65.21739
```

## Motivation
This helps users gauge how balanced their bull and bear models are without needing to manually filter the trades dataframe. As noted in the issue, this is useful for understanding strategy behavior.

## Implementation
Simple addition in `_stats.py` - counts trades based on the sign of the `Size` column:
- `Size > 0` = long trade
- `Size < 0` = short trade

## Test plan
- [ ] Existing tests pass (new stats computed alongside existing ones)
- [ ] Verify counts match manual filtering of trades dataframe

Fixes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)