### PR TITLE
Upstream rebase + Optuna optimizer, fixed_params, Avg. Drawdown B&H

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Alpha [%]                              450.62
 Beta                                     0.02
 Max. Drawdown [%]                      -33.08
 Avg. Drawdown [%]                       -5.58
+Avg. Drawdown Buy & Hold [%]            -5.45
 Max. Drawdown Duration      688 days 00:00:00
 Avg. Drawdown Duration       41 days 00:00:00
 # Trades                                   93

--- a/backtesting/_stats.py
+++ b/backtesting/_stats.py
@@ -47,6 +47,9 @@ def compute_stats(
     dd = 1 - equity / np.maximum.accumulate(equity)
     dd_dur, dd_peaks = compute_drawdown_duration_peaks(pd.Series(dd, index=index))
 
+    dd_asset = 1 - ohlc_data.Close.values / np.maximum.accumulate(ohlc_data.Close.values)
+    dd_dur_asset, dd_peaks_asset = compute_drawdown_duration_peaks(pd.Series(dd_asset, index=index))
+
     equity_df = pd.DataFrame({
         'Equity': equity,
         'DrawdownPct': dd,
@@ -165,6 +168,7 @@ def compute_stats(
     s.loc['Beta'] = beta
     s.loc['Max. Drawdown [%]'] = max_dd * 100
     s.loc['Avg. Drawdown [%]'] = -dd_peaks.mean() * 100
+    s.loc['Avg. Drawdown Buy & Hold [%]'] = -dd_peaks_asset.mean() * 100
     s.loc['Max. Drawdown Duration'] = _round_timedelta(dd_dur.max())
     s.loc['Avg. Drawdown Duration'] = _round_timedelta(dd_dur.mean())
     s.loc['# Trades'] = n_trades = len(trades_df)

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1240,7 +1240,7 @@ class Backtest:
         self._results: Optional[pd.Series] = None
         self._finalize_trades = bool(finalize_trades)
 
-    def run(self, **kwargs) -> pd.Series:
+    def run(self, *, fixed_params: dict | None = None, **kwargs) -> pd.Series:
         """
         Run the backtest. Returns `pd.Series` with results and statistics.
 
@@ -1293,6 +1293,8 @@ class Backtest:
         data = _Data(self._data.copy(deep=False))
         broker: _Broker = self._broker(data=data)
         strategy: Strategy = self._strategy(broker, data, kwargs)
+        if fixed_params:
+            strategy._check_params(fixed_params)
 
         strategy.init()
         data._update()  # Strategy.init might have changed/added to data.df
@@ -1363,6 +1365,7 @@ class Backtest:
                  return_heatmap: bool = False,
                  return_optimization: bool = False,
                  random_state: Optional[int] = None,
+                 fixed_params: dict | None = None,
                  **kwargs) -> Union[pd.Series,
                                     Tuple[pd.Series, pd.Series],
                                     Tuple[pd.Series, pd.Series, dict]]:
@@ -1513,7 +1516,7 @@ class Backtest:
                     bt = copy(self)  # bt._data will be reassigned in _mp_task worker
                 results = _tqdm(
                     pool.imap(Backtest._mp_task,
-                              ((bt, smm.df2shm(self._data), params_batch)
+                              ((bt, smm.df2shm(self._data), params_batch, fixed_params)
                                for params_batch in _batch(param_combos))),
                     total=len(param_combos),
                     desc='Backtest.optimize'
@@ -1526,10 +1529,10 @@ class Backtest:
             if pd.isnull(heatmap).all():
                 # No trade was made in any of the runs. Just make a random
                 # run so we get some, if empty, results
-                stats = self.run(**param_combos[0])
+                stats = self.run(**param_combos[0], fixed_params=fixed_params)
             else:
                 best_params = heatmap.idxmax(skipna=True)
-                stats = self.run(**dict(zip(heatmap.index.names, best_params)))
+                stats = self.run(**dict(zip(heatmap.index.names, best_params)), fixed_params=fixed_params)
 
             if return_heatmap:
                 return stats, heatmap
@@ -1567,7 +1570,7 @@ class Backtest:
             @lru_cache()
             def memoized_run(tup):
                 nonlocal maximize, self
-                stats = self.run(**dict(tup))
+                stats = self.run(**dict(tup), fixed_params=fixed_params)
                 return -maximize(stats)
 
             progress = iter(_tqdm(repeat(None), total=max_tries, leave=False,
@@ -1592,7 +1595,7 @@ class Backtest:
                 method='sceua',
                 rng=random_state)
 
-            stats = self.run(**dict(zip(kwargs.keys(), res.x)))
+            stats = self.run(**dict(zip(kwargs.keys(), res.x)), fixed_params=fixed_params)
             output = [stats]
 
             if return_heatmap:
@@ -1617,11 +1620,12 @@ class Backtest:
 
     @staticmethod
     def _mp_task(arg):
-        bt, data_shm, params_batch = arg
+        bt, data_shm, params_batch, *rest = arg
+        fixed_params = rest[0] if rest else None
         bt._data, shm = SharedMemoryManager.shm2df(data_shm)
         try:
             return [stats.filter(regex='^[^_]') if stats['# Trades'] else None
-                    for stats in (bt.run(**params)
+                    for stats in (bt.run(**params, fixed_params=fixed_params)
                                   for params in params_batch)]
         finally:
             for shmem in shm:

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1265,6 +1265,7 @@ class Backtest:
             Beta                                  0.03803
             Max. Drawdown [%]                   -47.98013
             Avg. Drawdown [%]                    -5.92585
+            Avg. Drawdown Buy & Hold [%]         -5.44945
             Max. Drawdown Duration      584 days 00:00:00
             Avg. Drawdown Duration       41 days 00:00:00
             # Trades                                   66

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -1367,6 +1367,10 @@ class Backtest:
                  return_optimization: bool = False,
                  random_state: Optional[int] = None,
                  fixed_params: dict | None = None,
+                 optuna_storage: Optional[str] = None,
+                 optuna_study_name: Optional[str] = None,
+                 optuna_sampler: str = 'tpe',
+                 progress_callback: Optional[Callable[[int, int, float], None]] = None,
                  **kwargs) -> Union[pd.Series,
                                     Tuple[pd.Series, pd.Series],
                                     Tuple[pd.Series, pd.Series, dict]]:
@@ -1386,8 +1390,12 @@ class Backtest:
           cartesian product of parameter combinations, and
         * `"sambo"` which finds close-to-optimal strategy parameters using
           [model-based optimization], making at most `max_tries` evaluations.
+        * `"optuna"` which uses [Optuna] for Bayesian optimization,
+          making at most `max_tries` evaluations. Supports persistent
+          storage and study resumption.
 
         [model-based optimization]: https://sambo-optimization.github.io
+        [Optuna]: https://optuna.org
 
         `max_tries` is the maximal number of strategy runs to perform.
         If `method="grid"`, this results in randomized grid search.
@@ -1419,6 +1427,21 @@ class Backtest:
 
         If you want reproducible optimization results, set `random_state`
         to a fixed integer random seed.
+
+        `optuna_storage` is an optional SQLAlchemy-compatible database URL
+        (e.g. ``"sqlite:///study.db"``) for persisting Optuna studies.
+        Only valid with ``method="optuna"``.
+
+        `optuna_study_name` is the name for the Optuna study. If not
+        provided, a name is auto-generated. Only valid with ``method="optuna"``.
+
+        `optuna_sampler` selects the Optuna sampling algorithm:
+        ``"tpe"`` (default), ``"cmaes"``, or ``"random"``.
+        Only valid with ``method="optuna"``.
+
+        `progress_callback` is an optional callable
+        ``(current_trial, max_trials, best_value)`` called after each
+        optimization trial. Currently only supported with ``method="optuna"``.
 
         Additional keyword arguments represent strategy arguments with
         list-like collections of possible values. For example, the following
@@ -1463,8 +1486,23 @@ class Backtest:
             method = 'sambo'
             warnings.warn('`Backtest.optimize(method="skopt")` is deprecated. Use `method="sambo"`.',
                           DeprecationWarning, stacklevel=2)
-        if return_optimization and method != 'sambo':
-            raise ValueError("return_optimization=True only valid if method='sambo'")
+        if return_optimization and method not in ('sambo', 'optuna'):
+            raise ValueError("return_optimization=True only valid if method='sambo' or method='optuna'")
+
+        if method != 'optuna':
+            if optuna_storage is not None:
+                raise ValueError("optuna_storage is only valid with method='optuna'")
+            if optuna_study_name is not None:
+                raise ValueError("optuna_study_name is only valid with method='optuna'")
+            if optuna_sampler != 'tpe':
+                raise ValueError("optuna_sampler is only valid with method='optuna'")
+
+        if method == 'optuna':
+            if return_heatmap:
+                raise ValueError("return_heatmap is not supported with method='optuna'")
+            if optuna_sampler not in ('tpe', 'cmaes', 'random'):
+                raise ValueError(f"optuna_sampler must be 'tpe', 'cmaes', or 'random', "
+                                 f"not {optuna_sampler!r}")
 
         def _tuple(x):
             return x if isinstance(x, Sequence) and not isinstance(x, str) else (x,)
@@ -1611,12 +1649,99 @@ class Backtest:
 
             return stats if len(output) == 1 else tuple(output)
 
+        def _optimize_optuna():
+            try:
+                import optuna
+            except ImportError:
+                raise ImportError(
+                    "Need package 'optuna' for method='optuna'. "
+                    "pip install optuna"
+                ) from None
+
+            optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+            nonlocal max_tries
+            max_tries = (200 if max_tries is None else
+                         max(1, int(max_tries * _grid_size())) if 0 < max_tries <= 1 else
+                         int(max_tries))
+
+            # Configure sampler
+            sampler_map = {
+                'tpe': lambda: optuna.samplers.TPESampler(seed=random_state),
+                'cmaes': lambda: optuna.samplers.CmaEsSampler(seed=random_state),
+                'random': lambda: optuna.samplers.RandomSampler(seed=random_state),
+            }
+            sampler = sampler_map[optuna_sampler]()
+
+            # Create or load study
+            from time import time
+            study_name = optuna_study_name
+            if study_name is None:
+                study_name = f'bt_{self._strategy.__name__}_{int(time()):x}'
+
+            study = optuna.create_study(
+                study_name=study_name,
+                storage=optuna_storage,
+                direction='maximize',
+                sampler=sampler,
+                load_if_exists=True,
+            )
+
+            # If resuming, reduce remaining trials
+            existing = sum(1 for t in study.trials
+                          if t.state == optuna.trial.TrialState.COMPLETE)
+            remaining = max(0, max_tries - existing)
+
+            param_names = list(kwargs.keys())
+
+            def objective(trial):
+                params = {}
+                for name in param_names:
+                    values = list(_tuple(kwargs[name]))
+                    params[name] = trial.suggest_categorical(name, values)
+
+                if not constraint(AttrDict(params)):
+                    raise optuna.TrialPruned()
+
+                stats = self.run(**params, fixed_params=fixed_params)
+                value = maximize(stats)
+                return value if not np.isnan(value) else float('-inf')
+
+            trial_count = 0
+
+            def _optuna_callback(study, trial):
+                nonlocal trial_count
+                trial_count += 1
+                if progress_callback is not None:
+                    try:
+                        best_value = study.best_value
+                    except ValueError:
+                        best_value = float('nan')
+                    progress_callback(trial_count, max_tries, best_value)
+
+            study.optimize(
+                objective,
+                n_trials=remaining,
+                callbacks=[_optuna_callback],
+            )
+
+            best_params = study.best_params
+            stats = self.run(**best_params, fixed_params=fixed_params)
+            output = [stats]
+
+            if return_optimization:
+                output.append(study)
+
+            return stats if len(output) == 1 else tuple(output)
+
         if method == 'grid':
             output = _optimize_grid()
         elif method in ('sambo', 'skopt'):
             output = _optimize_sambo()
+        elif method == 'optuna':
+            output = _optimize_optuna()
         else:
-            raise ValueError(f"Method should be 'grid' or 'sambo', not {method!r}")
+            raise ValueError(f"Method should be 'grid', 'sambo', or 'optuna', not {method!r}")
         return output
 
     @staticmethod

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -95,6 +95,20 @@ class TestBacktest(TestCase):
         )
         self.assertEqual(stats['_strategy'].fast, 5)
 
+    def test_method_optuna(self):
+        try:
+            import optuna  # noqa: F401
+        except ImportError:
+            self.skipTest("Optuna not installed")
+        stats = Backtest(GOOG, SmaCross).optimize(
+            fast=range(2, 10),
+            slow=range(10, 30),
+            method='optuna',
+            max_tries=20
+        )
+        self.assertIsInstance(stats, pd.Series)
+        self.assertIn('SQN', stats.index)
+
     def test_run_invalid_param(self):
         bt = Backtest(GOOG, SmaCross)
         self.assertRaises(AttributeError, bt.run, foo=3)

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -356,6 +356,7 @@ class TestBacktest(TestCase):
                 'Worst Trade [%]': -18.39887353835481,
                 'Alpha [%]': 394.37391142027462,
                 'Beta': 0.03803390709192,
+                'Avg. Drawdown Buy & Hold [%]': -5.44944935340632,
         })
 
         def almost_equal(a, b):

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -1177,3 +1177,10 @@ class TestRegressions(TestCase):
         trades = Backtest(SHORT_DATA, S).run()._trades
         self.assertEqual(trades['SL'].fillna(0).tolist(), [0, 99])
         self.assertEqual(trades['TP'].fillna(0).tolist(), [111, 0])
+
+    def test_avg_drawdown_buy_and_hold(self):
+        stats = Backtest(GOOG, SmaCross).run()
+        self.assertIn('Avg. Drawdown Buy & Hold [%]', stats.index)
+        self.assertIsInstance(stats['Avg. Drawdown Buy & Hold [%]'], float)
+        self.assertTrue(stats['Avg. Drawdown Buy & Hold [%]'] < 0,
+                        "Avg drawdown should be negative")

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -109,6 +109,95 @@ class TestBacktest(TestCase):
         self.assertIsInstance(stats, pd.Series)
         self.assertIn('SQN', stats.index)
 
+    def test_method_optuna_return_study(self):
+        try:
+            import optuna
+        except ImportError:
+            self.skipTest("Optuna not installed")
+        stats, study = Backtest(GOOG, SmaCross).optimize(
+            fast=range(2, 10),
+            slow=range(10, 30),
+            method='optuna',
+            max_tries=10,
+            return_optimization=True
+        )
+        self.assertIsInstance(stats, pd.Series)
+        self.assertIsInstance(study, optuna.study.Study)
+        self.assertGreater(len(study.trials), 0)
+
+    def test_method_optuna_resume(self):
+        try:
+            import optuna
+        except ImportError:
+            self.skipTest("Optuna not installed")
+        import tempfile, os
+        db_path = os.path.join(tempfile.gettempdir(), 'test_optuna_resume.db')
+        storage = f'sqlite:///{db_path}'
+        study_name = 'test_resume'
+        try:
+            # First run: 10 trials
+            Backtest(GOOG, SmaCross).optimize(
+                fast=range(2, 10), slow=range(10, 30),
+                method='optuna', max_tries=10,
+                optuna_storage=storage, optuna_study_name=study_name
+            )
+            # Second run: 20 total, should only do 10 more
+            stats, study = Backtest(GOOG, SmaCross).optimize(
+                fast=range(2, 10), slow=range(10, 30),
+                method='optuna', max_tries=20,
+                optuna_storage=storage, optuna_study_name=study_name,
+                return_optimization=True
+            )
+            completed = sum(1 for t in study.trials
+                            if t.state == optuna.trial.TrialState.COMPLETE)
+            self.assertEqual(completed, 20)
+        finally:
+            if os.path.exists(db_path):
+                os.unlink(db_path)
+
+    def test_method_optuna_progress_callback(self):
+        try:
+            import optuna  # noqa: F401
+        except ImportError:
+            self.skipTest("Optuna not installed")
+        calls = []
+        def callback(current, total, value):
+            calls.append((current, total, value))
+        Backtest(GOOG, SmaCross).optimize(
+            fast=range(2, 10), slow=range(10, 30),
+            method='optuna', max_tries=5,
+            progress_callback=callback
+        )
+        self.assertEqual(len(calls), 5)
+        self.assertEqual(calls[-1][0], 5)
+        self.assertEqual(calls[-1][1], 5)
+
+    def test_method_optuna_samplers(self):
+        try:
+            import optuna  # noqa: F401
+        except ImportError:
+            self.skipTest("Optuna not installed")
+        for sampler in ('tpe', 'cmaes', 'random'):
+            stats = Backtest(GOOG, SmaCross).optimize(
+                fast=range(2, 10), slow=range(10, 30),
+                method='optuna', max_tries=5,
+                optuna_sampler=sampler
+            )
+            self.assertIsInstance(stats, pd.Series)
+
+    def test_method_optuna_fixed_params(self):
+        try:
+            import optuna  # noqa: F401
+        except ImportError:
+            self.skipTest("Optuna not installed")
+        stats = Backtest(GOOG, SmaCross).optimize(
+            slow=range(10, 30),
+            method='optuna',
+            max_tries=5,
+            fixed_params={'fast': 5}
+        )
+        self.assertEqual(stats['_strategy'].fast, 5)
+
     def test_run_invalid_param(self):
         bt = Backtest(GOOG, SmaCross)
         self.assertRaises(AttributeError, bt.run, foo=3)

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -82,6 +82,19 @@ class TestBacktest(TestCase):
         bt = Backtest(EURUSD, SmaCross)
         bt.run()
 
+    def test_run_fixed_params(self):
+        """fixed_params should override strategy class attributes during run."""
+        stats = Backtest(GOOG, SmaCross).run(fixed_params={'fast': 5})
+        self.assertEqual(stats['_strategy'].fast, 5)
+
+    def test_optimize_fixed_params(self):
+        """fixed_params should be forwarded to run() during optimization."""
+        stats = Backtest(GOOG, SmaCross).optimize(
+            slow=range(10, 30, 5),
+            fixed_params={'fast': 5}
+        )
+        self.assertEqual(stats['_strategy'].fast, 5)
+
     def test_run_invalid_param(self):
         bt = Backtest(GOOG, SmaCross)
         self.assertRaises(AttributeError, bt.run, foo=3)


### PR DESCRIPTION
## Summary

Rebases our fork onto the latest upstream `kernc/backtesting.py` master (v0.6.5+, 155 commits ahead of our old base) and ports our custom features as clean, minimal patches:

- **Optuna optimizer** (`method="optuna"`) as a third optimization method alongside `grid` and `sambo` — with persistent storage, study resumption, sampler selection (TPE/CMA-ES/Random), and progress callback
- **`fixed_params`** for `run()` and `optimize()` — strategy parameters that stay constant during optimization
- **Avg. Drawdown Buy & Hold [%]** metric in stats — benchmark drawdown for comparison

### What's NOT ported (intentionally dropped)

- OpenBox optimizer (replaced by upstream's SAMBO + our Optuna)
- `LatinHypercubeSampler` / `samplers.py`
- `return_configs` / `init_configs`
- `outcome_constraints`

### What we gain from upstream

- SAMBO optimizer, FractionalBacktest, MultiBacktest
- Alpha/Beta/CAGR/Kelly stats, Order.tag, Commission tracking
- Critical bugfixes: Sharpe ratio, SL/TP logic, commission handling, memory optimization
- SharedMemory grid optimization, tqdm progress bars
- Python 3.9+ / Bokeh 3.0+ support

## Test plan

- [x] All 85 tests pass (76 upstream + 9 new)
- [x] No new lint errors introduced
- [x] Optuna tests cover: basic optimization, return_optimization, persistent storage + resume, progress callback, all 3 samplers, fixed_params integration
- [ ] Manual smoke test with production strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)