### PR TITLE
Fix read-only array error in FractionalBacktest indicator scaling

### DIFF
--- a/backtesting/lib.py
+++ b/backtesting/lib.py
@@ -552,9 +552,9 @@ class FractionalBacktest(Backtest):
         trades[['EntryPrice', 'ExitPrice', 'TP', 'SL']] /= self._fractional_unit
 
         indicators = result['_strategy']._indicators
-        for indicator in indicators:
+        for i, indicator in enumerate(indicators):
             if indicator._opts['overlay']:
-                indicator /= self._fractional_unit
+                indicators[i] = indicator / self._fractional_unit
 
         return result
 


### PR DESCRIPTION
Fixes the CI failure in test_FractionalBacktest where indicator /= self._fractional_unit raises ValueError: output array is read-only on newer pandas.

The in-place division fails because the underlying numpy array from pandas is read-only (copy-on-write). Replaced with a non-mutating division that creates a new array and updates the list entry directly.

Ref: #1354