### PR TITLE
Clarify commission parameter in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ stats = bt.run()
 bt.plot()
 ```
 
+In this example, `commission=.002` applies a **0.2% fee per trade**
+(fraction of traded value). See the API reference for `spread` and
+callable commission functions.
+
 Results in:
 
 ```text


### PR DESCRIPTION
## Summary
- Adds a short note below the README usage snippet explaining `commission=.002` as a 0.2% per-trade fee
- Points readers to `spread` and callable commission in the API reference

## Motivation
New users often miss that the commission argument is a fraction of traded value. The quick-start docs mention 0.2% in prose, but the README code sample does not.

## Test plan
- [x] Docs-only change

Made with [Cursor](https://cursor.com)