### PR TITLE
ENH: Multi-asset (portfolio) backtesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ These were the major changes contributing to each release:
 
 ### 0.x.x
 
+* **Multi-asset (portfolio) backtesting**: `Backtest(data=...)` now also accepts
+  a dict of OHLC data frames keyed by asset symbol (or a single data frame with
+  two-level `(symbol, field)` columns), trading all assets from one shared
+  cash/margin account. New API surface: `Strategy.buy/sell/I(symbol=...)`,
+  `Strategy.positions[symbol]`, `Strategy.data[symbol]` & `Strategy.data.symbols`,
+  `Order.symbol` / `Trade.symbol`, `Backtest.plot(symbol=...)`. Data is aligned
+  on the union of indexes with NaN marking non-traded bars (never forward/back-filled);
+  orders on such bars wait for the symbol's next traded bar. Single-asset behavior
+  is unchanged.
+* Indicators stored in a flat dict/list/tuple strategy attribute are now, like
+  plain indicator attributes, auto-sliced in `Strategy.next()` (a container mixing
+  indicators with other values raises an error), preventing accidental look-ahead.
+  `symbol` joins `name`/`plot`/`overlay`/`color`/`scatter` as a reserved
+  `Strategy.I()` keyword (no longer forwarded to the indicator function).
+* A `commission` callable declaring a third parameter named `symbol` (or three
+  required positional parameters) now receives the order's symbol, enabling
+  per-asset fee schedules; 2-arg callables work unchanged.
+* Bugfixes:
+  * Out-of-money liquidation and `exclusive_orders` cancellation no longer skip
+    every other trade/order (mutation-while-iterating).
+  * String/categorical indicators no longer crash the indicator warm-up
+    computation (they are excluded from it).
+
 ### 0.6.5
 (2025-07-30)
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,38 @@ dtype: object
 
 Find more usage examples in the [documentation].
 
+### Multi-asset (portfolio) backtesting
+
+Pass a dict of data frames (keyed by asset symbol) to trade a whole
+portfolio from a single shared account:
+
+```python
+class SmaCrossPortfolio(Strategy):
+    def init(self):
+        self.ma1 = {s: self.I(SMA, self.data[s].Close, 10, symbol=s)
+                    for s in self.data.symbols}
+        self.ma2 = {s: self.I(SMA, self.data[s].Close, 20, symbol=s)
+                    for s in self.data.symbols}
+
+    def next(self):
+        for s in self.data.symbols:
+            if crossover(self.ma1[s], self.ma2[s]):
+                self.buy(symbol=s, size=.3)
+            elif crossover(self.ma2[s], self.ma1[s]) and self.positions[s]:
+                self.positions[s].close()
+
+
+bt = Backtest({'AAPL': aapl, 'MSFT': msft, 'GOOG': goog},
+              SmaCrossPortfolio, cash=100_000, commission=.002)
+stats = bt.run()
+bt.plot(symbol='AAPL')
+```
+
+Assets may follow different calendars (e.g. crypto vs. equities, later
+IPOs); data is aligned on the union of timestamps, prices are never
+forward-filled, and orders for an asset simply wait until the asset's
+next traded bar. See the `Backtest` documentation for details.
+
 
 Features
 --------
@@ -103,6 +135,7 @@ Features
 * Library of composable base strategies and utilities
 * Indicator-library-agnostic
 * Supports _any_ financial instrument with candlestick data
+* Multi-asset portfolio backtesting from a single account
 * Detailed results
 * Interactive visualizations
 

--- a/backtesting/_stats.py
+++ b/backtesting/_stats.py
@@ -43,6 +43,7 @@ def compute_stats(
 ) -> pd.Series:
     assert -1 < risk_free_rate < 1
 
+    is_multiasset = isinstance(ohlc_data.columns, pd.MultiIndex)
     index = ohlc_data.index
     dd = 1 - equity / np.maximum.accumulate(equity)
     dd_dur, dd_peaks = compute_drawdown_duration_peaks(pd.Series(dd, index=index))
@@ -74,15 +75,26 @@ def compute_stats(
         })
         trades_df['Duration'] = trades_df['ExitTime'] - trades_df['EntryTime']
         trades_df['Tag'] = [t.tag for t in trades]
+        if is_multiasset:
+            trades_df.insert(0, 'Symbol', [t.symbol for t in trades])
 
         # Add indicator values
         if len(trades_df) and strategy_instance:
             for ind in strategy_instance._indicators:
+                ind_symbol = ind._opts.get('symbol')
                 ind = np.atleast_2d(ind)
                 for i, values in enumerate(ind):  # multi-d indicators
                     suffix = f'_{i}' if len(ind) > 1 else ''
-                    trades_df[f'Entry_{ind.name}{suffix}'] = values[trades_df['EntryBar'].values]
-                    trades_df[f'Exit_{ind.name}{suffix}'] = values[trades_df['ExitBar'].values]
+                    entry_values = values[trades_df['EntryBar'].values]
+                    exit_values = values[trades_df['ExitBar'].values]
+                    if ind_symbol is not None:
+                        # A symbol-associated indicator is only meaningful
+                        # on that symbol's own trades
+                        of_symbol = (trades_df['Symbol'] == ind_symbol).values
+                        entry_values = np.where(of_symbol, entry_values, np.nan)
+                        exit_values = np.where(of_symbol, exit_values, np.nan)
+                    trades_df[f'Entry_{ind.name}{suffix}'] = entry_values
+                    trades_df[f'Exit_{ind.name}{suffix}'] = exit_values
 
         commissions = sum(t._commissions for t in trades)
     del trades
@@ -112,8 +124,21 @@ def compute_stats(
     if commissions:
         s.loc['Commissions [$]'] = commissions
     s.loc['Return [%]'] = (equity[-1] - equity[0]) / equity[0] * 100
-    first_trading_bar = _indicator_warmup_nbars(strategy_instance)
-    c = ohlc_data.Close.values
+    # Min for never-warm multi-asset indicator groups, where warmup == len(index)
+    first_trading_bar = min(_indicator_warmup_nbars(strategy_instance), len(index) - 1)
+    if is_multiasset:
+        # The multi-asset benchmark (for Buy & Hold, Beta and Alpha) is an
+        # equal-weighted, per-bar-rebalanced basket index over all assets.
+        # Each asset contributes returns between its first and last traded
+        # bars; on its non-traded bars in between, its mark (and thus its
+        # contribution) is unchanged.
+        closes = ohlc_data.xs('Close', axis=1, level=1)
+        listed = closes.notna()
+        alive = listed.cummax() & listed[::-1].cummax()[::-1]
+        asset_returns = closes.ffill().pct_change().where(alive)
+        c = (1 + asset_returns.mean(axis=1).fillna(0)).cumprod().values
+    else:
+        c = ohlc_data.Close.values
     s.loc['Buy & Hold Return [%]'] = (c[-1] - c[first_trading_bar]) / c[first_trading_bar] * 100  # long-only return
 
     gmean_day_return: float = 0

--- a/backtesting/_util.py
+++ b/backtesting/_util.py
@@ -4,13 +4,14 @@ import os
 import sys
 import warnings
 from contextlib import contextmanager
+from difflib import get_close_matches
 from functools import partial
 from itertools import chain
 from multiprocessing import resource_tracker as _mprt
 from multiprocessing import shared_memory as _mpshm
 from numbers import Number
 from threading import Lock
-from typing import Dict, List, Optional, Sequence, Union, cast
+from typing import Dict, List, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -79,18 +80,99 @@ def _data_period(index) -> Union[pd.Timedelta, Number]:
 
 
 def _strategy_indicators(strategy):
-    return {attr: indicator
-            for attr, indicator in strategy.__dict__.items()
-            if isinstance(indicator, _Indicator)}.items()
+    """
+    Return `[(attr, value), ...]` of strategy attributes to auto-slice in
+    `Strategy.next()`, where each value is an `_Indicator` or a flat
+    dict/list/tuple thereof. Containers mixing indicators with other values
+    raise, lest a full-length (future-containing) array slips through.
+    """
+    def _items(value):
+        if isinstance(value, dict):
+            return list(value.values())
+        if isinstance(value, (list, tuple)):
+            return list(value)
+        return None
+
+    pairs = []
+    for attr, value in strategy.__dict__.items():
+        if attr == '_indicators':  # Strategy-internal registry of all I() results
+            continue
+        if isinstance(value, _Indicator):
+            pairs.append((attr, value))
+            continue
+        items = _items(value)
+        if not items:
+            continue
+        if all(isinstance(item, _Indicator) for item in items):
+            pairs.append((attr, value))
+        elif any(isinstance(item, _Indicator)
+                 for item in chain(items, *filter(None, map(_items, items)))):
+            raise ValueError(
+                f'Strategy attribute {attr!r} mixes indicators declared with '
+                '`Strategy.I()` with other values and cannot be safely '
+                'auto-sliced in `Strategy.next()`. Store indicators in their '
+                'own flat dict/list/tuple.')
+    return pairs
+
+
+def _as_indicators(value) -> List['_Indicator']:
+    """`_strategy_indicators` value (indicator or container) as a flat list."""
+    if isinstance(value, _Indicator):
+        return [value]
+    return list(value.values() if isinstance(value, dict) else value)
+
+
+def _indicator_sliced(value, length):
+    """`value` (an `_Indicator` or a container from `_strategy_indicators`)
+    with each indicator array revealed only up to `length` bars."""
+    if isinstance(value, _Indicator):
+        return value[..., :length]
+    if isinstance(value, dict):
+        return {key: indicator[..., :length] for key, indicator in value.items()}
+    items = (indicator[..., :length] for indicator in value)
+    cls = type(value)
+    return cls(*items) if hasattr(cls, '_fields') else cls(items)  # namedtuple or list/tuple
 
 
 def _indicator_warmup_nbars(strategy):
+    """
+    Number of leading bars to skip so the backtest starts with valid indicators.
+
+    Single-asset: the first bar on which every (non-scatter) indicator is
+    non-NaN. Multi-asset: indicators are grouped by their `Strategy.I(symbol=)`
+    tag (untagged indicators belong to every group), and the backtest starts
+    as soon as the earliest-ready symbol group is warm; not-yet-warm symbols'
+    indicators are simply still NaN in `Strategy.next()`.
+    """
     if strategy is None:
         return 0
-    nbars = max((np.isnan(indicator.astype(float)).argmin(axis=-1).max()
-                 for _, indicator in _strategy_indicators(strategy)
-                 if not indicator._opts['scatter']), default=0)
-    return nbars
+    indicators = [
+        (indicator._opts.get('symbol'), np.isnan(as_float))
+        for _, value in _strategy_indicators(strategy)
+        for indicator in _as_indicators(value)
+        if not indicator._opts['scatter'] and
+        # Skip e.g. categorical indicators, which never warm up
+        (as_float := try_(lambda: indicator.astype(float),  # noqa: B023
+                          exception=(TypeError, ValueError))) is not None]
+    symbols = tuple(getattr(strategy._data, 'symbols', ()) or ())
+    if not symbols:
+        return max((isnan.argmin(axis=-1).max()
+                    for _, isnan in indicators), default=0)
+
+    n_data = len(strategy._data)
+
+    def first_valid(isnan):
+        # An all-NaN indicator (row) never becomes valid
+        return n_data if isnan.all(axis=-1).any() else isnan.argmin(axis=-1).max()
+
+    untagged = max((first_valid(isnan) for symbol, isnan in indicators
+                    if symbol is None), default=0)
+    group_warmup = [
+        max([untagged, *(first_valid(isnan) for ind_symbol, isnan in indicators
+                         if ind_symbol == symbol)])
+        for symbol in symbols]
+    ready = [nbars for nbars in group_warmup if nbars < n_data]
+    return min(ready) if ready else n_data
 
 
 class _Array(np.ndarray):
@@ -159,9 +241,17 @@ class _Data:
     as a standard `pd.DataFrame` would, except it's not a DataFrame
     and the returned "series" are _not_ `pd.Series` but `np.ndarray`
     for performance reasons.
+
+    In multi-asset mode (two-level `(symbol, field)` DataFrame columns),
+    `data[symbol]` returns a per-symbol `_Data` view whose revealed length
+    is slaved to this parent's, and top-level field access raises.
     """
     def __init__(self, df: pd.DataFrame):
         self.__df = df
+        self.__symbols: Tuple[str, ...] = (
+            tuple(df.columns.get_level_values(0).unique())
+            if isinstance(df.columns, pd.MultiIndex) else ())
+        self.__children: Dict[str, _Data] = {}
         self.__len = len(df)  # Current length
         self.__pip: Optional[float] = None
         self.__cache: Dict[str, _Array] = {}
@@ -169,6 +259,14 @@ class _Data:
         self._update()
 
     def __getitem__(self, item):
+        if item is None and not self.__symbols:
+            return self  # data[None] is data; allows symbol-generic strategy code
+        if isinstance(item, str) and item in self.__symbols:
+            child = self.__children.get(item)
+            if child is None:
+                child = self.__children[item] = _Data(self.__df[item])
+                child._set_length(self.__len)
+            return child
         return self.__get_array(item)
 
     def __getattr__(self, item):
@@ -177,9 +275,16 @@ class _Data:
         except KeyError:
             raise AttributeError(f"Column '{item}' not in data") from None
 
+    @property
+    def symbols(self) -> Tuple[str, ...]:
+        """Asset symbols in multi-asset mode, or an empty tuple."""
+        return self.__symbols
+
     def _set_length(self, length):
         self.__len = length
         self.__cache.clear()
+        for child in self.__children.values():
+            child._set_length(length)
 
     def _update(self):
         index = self.__df.index.copy()
@@ -187,6 +292,11 @@ class _Data:
                          for col, arr in self.__df.items()}
         # Leave index as Series because pd.Timestamp nicer API to work with
         self.__arrays['__index'] = index
+        for symbol, child in self.__children.items():
+            # Refresh the child's data snapshot, but keep the child object
+            # (references captured in `Strategy.init` stay slaved to `_set_length`)
+            child.__df = self.__df[symbol]
+            child._update()
 
     def __repr__(self):
         i = min(self.__len, len(self.__df)) - 1
@@ -206,14 +316,34 @@ class _Data:
     @property
     def pip(self) -> float:
         if self.__pip is None:
+            if self.__symbols:
+                raise AttributeError(
+                    "'pip' is ambiguous in multi-asset mode; use `data[symbol].pip`. "
+                    f'Symbols: {self.__symbols}')
+            close = self.__arrays['Close']
+            close = close[close == close]  # Drop NaN of multi-asset data gaps
             self.__pip = float(10**-np.median([len(s.partition('.')[-1])
-                                               for s in self.__arrays['Close'].astype(str)]))
+                                               for s in close.astype(str)]))
         return self.__pip
 
     def __get_array(self, key) -> _Array:
         arr = self.__cache.get(key)
         if arr is None:
-            arr = self.__cache[key] = cast(_Array, self.__arrays[key][:self.__len])
+            try:
+                arr = self.__cache[key] = cast(_Array, self.__arrays[key][:self.__len])
+            except KeyError:
+                if self.__symbols:
+                    if key in ('Open', 'High', 'Low', 'Close', 'Volume', 'pip'):
+                        raise AttributeError(
+                            f'{key!r} is ambiguous in multi-asset mode; '
+                            f'use `data[symbol].{key}`. Symbols: {self.__symbols}') from None
+                    suggestions = get_close_matches(str(key), map(str, self.__symbols))
+                    hint = (f" Did you mean: {', '.join(map(repr, suggestions))}?"
+                            if suggestions else '')
+                    raise AttributeError(
+                        f'Unknown symbol or column {key!r}; '
+                        f'symbols: {self.__symbols}.{hint}') from None
+                raise
         return arr
 
     @property
@@ -329,9 +459,15 @@ class SharedMemoryManager:
     @staticmethod
     def shm2df(data_shm):
         shm = [SharedMemory(name=name, create=False, track=False) for _, name, _, _ in data_shm]
+        # NOTE: The str _DF_INDEX_COL key coexisting with any tuple column keys
+        # (multi-asset data) is what keeps this constructor from prematurely
+        # auto-building a MultiIndex
         df = pd.DataFrame({
             col: SharedMemoryManager.shm2s(shm, shape, dtype)
             for shm, (col, _, shape, dtype) in zip(shm, data_shm)})
         df.set_index(SharedMemoryManager._DF_INDEX_COL, drop=True, inplace=True)
         df.index.name = None
+        if len(df.columns) and all(isinstance(col, tuple) for col in df.columns):
+            # Restore multi-asset (symbol, field) columns flattened by the dict above
+            df.columns = pd.MultiIndex.from_tuples(df.columns, names=('Symbol', None))
         return df, shm

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -14,10 +14,12 @@ from abc import ABCMeta, abstractmethod
 from copy import copy
 from difflib import get_close_matches
 from functools import lru_cache, partial
+from inspect import Parameter, signature
 from itertools import chain, product, repeat
 from math import copysign
 from numbers import Number
-from typing import Callable, List, Optional, Sequence, Tuple, Type, Union
+from types import MappingProxyType
+from typing import Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 import pandas as pd
@@ -26,8 +28,8 @@ from numpy.random import default_rng
 from ._plotting import plot  # noqa: I001
 from ._stats import compute_stats, dummy_stats
 from ._util import (
-    SharedMemoryManager, _as_str, _Indicator, _Data, _batch, _indicator_warmup_nbars,
-    _strategy_indicators, patch, try_, _tqdm,
+    SharedMemoryManager, _as_str, _Indicator, _Data, _batch, _data_period,
+    _indicator_sliced, _indicator_warmup_nbars, _strategy_indicators, patch, try_, _tqdm,
 )
 
 __pdoc__ = {
@@ -77,6 +79,7 @@ class Strategy(metaclass=ABCMeta):
     def I(self,  # noqa: E743
           func: Callable, *args,
           name=None, plot=True, overlay=None, color=None, scatter=False,
+          symbol: Optional[str] = None,
           **kwargs) -> np.ndarray:
         """
         Declare an indicator. An indicator is just an array of values
@@ -109,6 +112,16 @@ class Strategy(metaclass=ABCMeta):
         If `scatter` is `True`, the plotted indicator marker will be a
         circle instead of a connected line segment (default).
 
+        In a multi-asset backtest (see `backtesting.backtesting.Backtest`),
+        pass `symbol` to associate the indicator with one of the assets.
+        The association is used for plotting (`Backtest.plot(symbol=...)`)
+        and for computing the warm-up period below: the backtest begins as
+        soon as the indicators of the earliest-ready symbol (together with
+        all unassociated indicators) are non-NaN, so indicators of other,
+        later-starting symbols may still be NaN in
+        `backtesting.backtesting.Strategy.next`. NaN comparisons are always
+        `False`, i.e. no signal.
+
         Additional `*args` and `**kwargs` are passed to `func` and can
         be used for parameters.
 
@@ -124,6 +137,8 @@ class Strategy(metaclass=ABCMeta):
             strategy that uses a 200-bar MA).
             This can affect results.
         """
+        symbol = self._resolve_symbol(symbol)
+
         def _format_name(name: str) -> str:
             return name.format(*map(_as_str, args),
                                **dict(zip(kwargs.keys(), map(_as_str, kwargs.values()))))
@@ -132,6 +147,8 @@ class Strategy(metaclass=ABCMeta):
             params = ','.join(filter(None, map(_as_str, chain(args, kwargs.values()))))
             func_name = _as_str(func)
             name = (f'{func_name}({params})' if params else f'{func_name}')
+            if symbol is not None:
+                name = f'{symbol}: {name}'
         elif isinstance(name, str):
             name = _format_name(name)
         elif try_(lambda: all(isinstance(item, str) for item in name), False):
@@ -161,21 +178,24 @@ class Strategy(metaclass=ABCMeta):
                 f'Length of `name=` ({len(name)}) must agree with the number '
                 f'of arrays the indicator returns ({value.shape[0]}).')
 
-        if not is_arraylike or not 1 <= value.ndim <= 2 or value.shape[-1] != len(self._data.Close):
+        if not is_arraylike or not 1 <= value.ndim <= 2 or value.shape[-1] != len(self._data):
             raise ValueError(
                 'Indicators must return (optionally a tuple of) numpy.arrays of same '
-                f'length as `data` (data shape: {self._data.Close.shape}; indicator "{name}" '
+                f'length as `data` (data length: {len(self._data)}; indicator "{name}" '
                 f'shape: {getattr(value, "shape", "")}, returned value: {value})')
 
         if overlay is None and np.issubdtype(value.dtype, np.number):
-            x = value / self._data.Close
-            # By default, overlay if strong majority of indicator values
-            # is within 30% of Close
-            with np.errstate(invalid='ignore'):
-                overlay = ((x < 1.4) & (x > .6)).mean() > .6
+            if self._data.symbols and symbol is None:
+                overlay = False  # No single price series to overlay onto
+            else:
+                x = value / self._data[symbol].Close
+                # By default, overlay if strong majority of indicator values
+                # is within 30% of Close
+                with np.errstate(invalid='ignore'):
+                    overlay = ((x < 1.4) & (x > .6)).mean() > .6
 
         value = _Indicator(value, name=name, plot=plot, overlay=overlay,
-                           color=color, scatter=scatter,
+                           color=color, scatter=scatter, symbol=symbol,
                            # _Indicator.s Series accessor uses this:
                            index=self.data.index)
         self._indicators.append(value)
@@ -222,14 +242,19 @@ class Strategy(metaclass=ABCMeta):
             stop: Optional[float] = None,
             sl: Optional[float] = None,
             tp: Optional[float] = None,
-            tag: object = None) -> 'Order':
+            tag: object = None,
+            symbol: Optional[str] = None) -> 'Order':
         """
         Place a new long order and return it. For explanation of parameters, see `Order`
         and its properties.
         Unless you're running `Backtest(..., trade_on_close=True)`,
-        market orders are filled on next bar's open,
+        market orders are filled on next bar's open (in a multi-asset backtest,
+        on the next bar _on which the symbol trades_),
         whereas other order types (limit, stop-limit, stop-market) are filled when
         the respective conditions are met.
+
+        In a multi-asset backtest, `symbol` is required and routes the order
+        to one of the `Strategy.data` symbols.
 
         See `Position.close()` and `Trade.close()` for closing existing positions.
 
@@ -237,7 +262,9 @@ class Strategy(metaclass=ABCMeta):
         """
         assert 0 < size < 1 or round(size) == size >= 1, \
             "size must be a positive fraction of equity, or a positive whole number of units"
-        return self._broker.new_order(size, limit, stop, sl, tp, tag)
+        symbol = self._resolve_symbol(symbol, required=True)
+        self.__warn_multiasset_full_equity(size)
+        return self._broker.new_order(size, limit, stop, sl, tp, tag, symbol=symbol)
 
     def sell(self, *,
              size: float = _FULL_EQUITY,
@@ -245,10 +272,14 @@ class Strategy(metaclass=ABCMeta):
              stop: Optional[float] = None,
              sl: Optional[float] = None,
              tp: Optional[float] = None,
-             tag: object = None) -> 'Order':
+             tag: object = None,
+             symbol: Optional[str] = None) -> 'Order':
         """
         Place a new short order and return it. For explanation of parameters, see `Order`
         and its properties.
+
+        In a multi-asset backtest, `symbol` is required and routes the order
+        to one of the `Strategy.data` symbols.
 
         .. caution::
             Keep in mind that `self.sell(size=.1)` doesn't close existing `self.buy(size=.1)`
@@ -268,7 +299,40 @@ class Strategy(metaclass=ABCMeta):
         """
         assert 0 < size < 1 or round(size) == size >= 1, \
             "size must be a positive fraction of equity, or a positive whole number of units"
-        return self._broker.new_order(-size, limit, stop, sl, tp, tag)
+        symbol = self._resolve_symbol(symbol, required=True)
+        self.__warn_multiasset_full_equity(size)
+        return self._broker.new_order(-size, limit, stop, sl, tp, tag, symbol=symbol)
+
+    def _resolve_symbol(self, symbol: Optional[str], *, required: bool = False) -> Optional[str]:
+        symbols = self._data.symbols
+        if not symbols:
+            if symbol is not None:
+                raise ValueError(
+                    f'symbol={symbol!r} passed, but this is a single-asset backtest. '
+                    'For multi-asset mode, pass `Backtest(data={...}, ...)` '
+                    'a dict of data frames.')
+            return None
+        if symbol is None:
+            if required:
+                raise ValueError(
+                    'Multi-asset mode requires explicit order routing, e.g. '
+                    f'`self.buy(symbol={symbols[0]!r}, ...)`. Symbols: {symbols}')
+            return None
+        if symbol not in symbols:
+            suggestions = get_close_matches(str(symbol), map(str, symbols))
+            hint = f" Did you mean: {', '.join(map(repr, suggestions))}?" if suggestions else ''
+            raise ValueError(f'Unknown symbol {symbol!r}; symbols: {symbols}.' + hint)
+        return symbol
+
+    def __warn_multiasset_full_equity(self, size):
+        broker = self._broker
+        if size is self._FULL_EQUITY and broker._symbols and not broker._warned_full_equity:
+            broker._warned_full_equity = True
+            warnings.warn(
+                'Order placed with default size= uses ~all available margin, '
+                'leaving none for the other assets. In a multi-asset backtest, '
+                'you likely want an explicit fractional size (e.g. `size=.2`) '
+                'or a number of units per order.', category=UserWarning, stacklevel=3)
 
     @property
     def equity(self) -> float:
@@ -301,13 +365,38 @@ class Strategy(metaclass=ABCMeta):
           **Pandas series**, you can call their `.s` accessor
           (e.g. `data.Close.s`). If you need the whole of data
           as a **DataFrame**, use `.df` accessor (i.e. `data.df`).
+
+        In a multi-asset backtest (see `backtesting.backtesting.Backtest`),
+        the per-asset series are accessed as `data[symbol].Close` etc.,
+        with available symbols listed in `data.symbols` (an empty tuple in
+        single-asset mode). The arrays span the **union** of all assets'
+        timestamps; bars on which an asset didn't trade hold NaN.
         """
         return self._data
 
     @property
     def position(self) -> 'Position':
-        """Instance of `backtesting.backtesting.Position`."""
+        """
+        Instance of `backtesting.backtesting.Position`.
+
+        In a multi-asset backtest, an aggregate position is ambiguous;
+        use `Strategy.positions` instead.
+        """
+        if self._data.symbols:
+            raise RuntimeError(
+                '`self.position` is ambiguous in multi-asset mode; '
+                'use `self.positions[symbol]`')
         return self._broker.position
+
+    @property
+    def positions(self) -> 'Mapping[Optional[str], Position]':
+        """
+        Read-only mapping of symbol → `backtesting.backtesting.Position`.
+        In single-asset mode, the sole `Position` is keyed by `None`,
+        so `self.positions[symbol]` works in strategies generic over
+        `for symbol in (self.data.symbols or (None,)): ...`.
+        """
+        return MappingProxyType(self._broker.positions)
 
     @property
     def orders(self) -> 'Tuple[Order, ...]':
@@ -335,26 +424,36 @@ class Position:
         if self.position:
             ...  # we have a position, either long or short
     """
-    def __init__(self, broker: '_Broker'):
+    def __init__(self, broker: '_Broker', symbol: Optional[str] = None):
         self.__broker = broker
+        self.__symbol = symbol
+
+    def __trades(self) -> 'List[Trade]':
+        return [trade for trade in self.__broker.trades
+                if self.__symbol is None or trade.symbol == self.__symbol]
 
     def __bool__(self):
         return self.size != 0
 
     @property
+    def symbol(self) -> Optional[str]:
+        """Symbol this position pertains to, or None in single-asset mode."""
+        return self.__symbol
+
+    @property
     def size(self) -> float:
         """Position size in units of asset. Negative if position is short."""
-        return sum(trade.size for trade in self.__broker.trades)
+        return sum(trade.size for trade in self.__trades())
 
     @property
     def pl(self) -> float:
         """Profit (positive) or loss (negative) of the current position in cash units."""
-        return sum(trade.pl for trade in self.__broker.trades)
+        return sum(trade.pl for trade in self.__trades())
 
     @property
     def pl_pct(self) -> float:
         """Profit (positive) or loss (negative) of the current position in percent."""
-        total_invested = sum(trade.entry_price * abs(trade.size) for trade in self.__broker.trades)
+        total_invested = sum(trade.entry_price * abs(trade.size) for trade in self.__trades())
         return (self.pl / total_invested) * 100 if total_invested else 0
 
     @property
@@ -371,15 +470,24 @@ class Position:
         """
         Close portion of position by closing `portion` of each active trade. See `Trade.close`.
         """
-        for trade in self.__broker.trades:
+        for trade in self.__trades():
             trade.close(portion)
 
     def __repr__(self):
-        return f'<Position: {self.size} ({len(self.__broker.trades)} trades)>'
+        symbol = f' {self.__symbol}' if self.__symbol is not None else ''
+        return f'<Position{symbol}: {self.size} ({len(self.__trades())} trades)>'
 
 
 class _OutOfMoneyError(Exception):
     pass
+
+
+class _Positions(dict):
+    """Mapping of symbol → `Position` with helpful `KeyError`s."""
+    def __missing__(self, key):
+        suggestions = get_close_matches(str(key), map(str, self))
+        hint = f" Did you mean: {', '.join(map(repr, suggestions))}?" if suggestions else ''
+        raise KeyError(f'Unknown symbol {key!r}; symbols: {tuple(self)}.{hint}')
 
 
 class Order:
@@ -404,7 +512,9 @@ class Order:
                  sl_price: Optional[float] = None,
                  tp_price: Optional[float] = None,
                  parent_trade: Optional['Trade'] = None,
-                 tag: object = None):
+                 tag: object = None,
+                 *,
+                 symbol: Optional[str] = None):
         self.__broker = broker
         assert size != 0
         self.__size = size
@@ -414,6 +524,7 @@ class Order:
         self.__tp_price = tp_price
         self.__parent_trade = parent_trade
         self.__tag = tag
+        self.__symbol = symbol
 
     def _replace(self, **kwargs):
         for k, v in kwargs.items():
@@ -423,6 +534,7 @@ class Order:
     def __repr__(self):
         return '<Order {}>'.format(', '.join(f'{param}={try_(lambda: round(value, 5), value)!r}'
                                              for param, value in (
+                                                 ('symbol', self.__symbol),
                                                  ('size', self.__size),
                                                  ('limit', self.__limit_price),
                                                  ('stop', self.__stop_price),
@@ -501,6 +613,14 @@ class Order:
         return self.__parent_trade
 
     @property
+    def symbol(self) -> Optional[str]:
+        """
+        Symbol the order is routed to in a multi-asset backtest
+        (see `backtesting.backtesting.Backtest`), or None in single-asset mode.
+        """
+        return self.__symbol
+
+    @property
     def tag(self):
         """
         Arbitrary value (such as a string) which, if set, enables tracking
@@ -544,7 +664,8 @@ class Trade:
     When an `Order` is filled, it results in an active `Trade`.
     Find active trades in `Strategy.trades` and closed, settled trades in `Strategy.closed_trades`.
     """
-    def __init__(self, broker: '_Broker', size: int, entry_price: float, entry_bar, tag):
+    def __init__(self, broker: '_Broker', size: int, entry_price: float, entry_bar, tag, *,
+                 symbol: Optional[str] = None):
         self.__broker = broker
         self.__size = size
         self.__entry_price = entry_price
@@ -554,10 +675,13 @@ class Trade:
         self.__sl_order: Optional[Order] = None
         self.__tp_order: Optional[Order] = None
         self.__tag = tag
+        self.__symbol = symbol
         self._commissions = 0
 
     def __repr__(self):
-        return f'<Trade size={self.__size} time={self.__entry_bar}-{self.__exit_bar or ""} ' \
+        return f'<Trade ' \
+               f'{"symbol=" + str(self.__symbol) + " " if self.__symbol is not None else ""}' \
+               f'size={self.__size} time={self.__entry_bar}-{self.__exit_bar or ""} ' \
                f'price={self.__entry_price}-{self.__exit_price or ""} pl={self.pl:.0f}' \
                f'{" tag=" + str(self.__tag) if self.__tag is not None else ""}>'
 
@@ -574,7 +698,8 @@ class Trade:
         assert 0 < portion <= 1, "portion must be a fraction between 0 and 1"
         # Ensure size is an int to avoid rounding errors on 32-bit OS
         size = copysign(max(1, int(round(abs(self.__size) * portion))), -self.__size)
-        order = Order(self.__broker, size, parent_trade=self, tag=self.__tag)
+        order = Order(self.__broker, size, parent_trade=self, tag=self.__tag,
+                      symbol=self.__symbol)
         self.__broker.orders.insert(0, order)
 
     # Fields getters
@@ -606,6 +731,14 @@ class Trade:
         (or None if the trade is still active).
         """
         return self.__exit_bar
+
+    @property
+    def symbol(self) -> Optional[str]:
+        """
+        Symbol the trade is in, in a multi-asset backtest
+        (see `backtesting.backtesting.Backtest`), or None in single-asset mode.
+        """
+        return self.__symbol
 
     @property
     def tag(self):
@@ -658,13 +791,13 @@ class Trade:
         Trade profit (positive) or loss (negative) in cash units.
         Commissions are reflected only after the Trade is closed.
         """
-        price = self.__exit_price or self.__broker.last_price
+        price = self.__exit_price or self.__broker._last_price(self.__symbol)
         return (self.__size * (price - self.__entry_price)) - self._commissions
 
     @property
     def pl_pct(self):
         """Trade profit (positive) or loss (negative) in percent relative to trade entry price."""
-        price = self.__exit_price or self.__broker.last_price
+        price = self.__exit_price or self.__broker._last_price(self.__symbol)
         gross_pl_pct = copysign(1, self.__size) * (price / self.__entry_price - 1)
 
         # Total commission across the entire trade size to individual units
@@ -674,7 +807,7 @@ class Trade:
     @property
     def value(self):
         """Trade total value in cash (volume × price)."""
-        price = self.__exit_price or self.__broker.last_price
+        price = self.__exit_price or self.__broker._last_price(self.__symbol)
         return abs(self.__size) * price
 
     # SL/TP management API
@@ -728,10 +861,12 @@ class _Broker:
         assert cash > 0, f"cash should be > 0, is {cash}"
         assert 0 < margin <= 1, f"margin should be between 0 and 1, is {margin}"
         self._data: _Data = data
+        symbols = getattr(data, 'symbols', ())  # `data` is a raw df in `dummy_stats()`
+        self._symbols: Tuple[str, ...] = symbols if isinstance(symbols, tuple) else ()
         self._cash = cash
 
         if callable(commission):
-            self._commission = commission
+            self._commission = self._symbol_aware(commission)
         else:
             try:
                 self._commission_fixed, self._commission_relative = commission
@@ -753,10 +888,43 @@ class _Broker:
         self.orders: List[Order] = []
         self.trades: List[Trade] = []
         self.position = Position(self)
+        self.positions: Mapping[Optional[str], Position] = _Positions(
+            {symbol: Position(self, symbol) for symbol in self._symbols}
+            if self._symbols else {None: self.position})
         self.closed_trades: List[Trade] = []
+        # Per-symbol last valid (non-NaN) close ≤ the current bar,
+        # for marking to market across multi-asset data gaps
+        self._last_close: Dict[Optional[str], float] = {}
+        self._warned_full_equity = False
 
-    def _commission_func(self, order_size, price):
+    def _commission_func(self, order_size, price, symbol=None):
         return self._commission_fixed + abs(order_size) * price * self._commission_relative
+
+    @staticmethod
+    def _symbol_aware(commission_func):
+        """
+        Adapt a user `commission` callable to a uniform 3-arg
+        `func(order_size, price, symbol)` call convention. The symbol is only
+        passed to callables that explicitly accept it — a third _required_
+        positional parameter or a parameter named 'symbol' — so legacy 2-arg
+        callables (even with extra defaulted parameters) work unchanged.
+        """
+        try:
+            params = list(signature(commission_func).parameters.values())
+        except (TypeError, ValueError):
+            params = None
+        if params is not None:
+            positional = [p for p in params
+                          if p.kind in (Parameter.POSITIONAL_ONLY,
+                                        Parameter.POSITIONAL_OR_KEYWORD)]
+            if (sum(p.default is Parameter.empty for p in positional) >= 3 or
+                    any(p.name == 'symbol' for p in positional[2:])):
+                return commission_func
+            if any(p.name == 'symbol' and p.kind is Parameter.KEYWORD_ONLY
+                   for p in params):
+                return lambda order_size, price, symbol=None: \
+                    commission_func(order_size, price, symbol=symbol)
+        return lambda order_size, price, symbol=None: commission_func(order_size, price)
 
     def __repr__(self):
         return f'<Broker: {self._cash:.0f}{self.position.pl:+.1f} ({len(self.trades)} trades)>'
@@ -769,7 +937,8 @@ class _Broker:
                   tp: Optional[float] = None,
                   tag: object = None,
                   *,
-                  trade: Optional[Trade] = None) -> Order:
+                  trade: Optional[Trade] = None,
+                  symbol: Optional[str] = None) -> Order:
         """
         Argument size indicates whether the order is long or short
         """
@@ -779,9 +948,18 @@ class _Broker:
         sl = sl and float(sl)
         tp = tp and float(tp)
 
+        if trade is not None:
+            symbol = trade.symbol
+
         is_long = size > 0
         assert size != 0, size
-        adjusted_price = self._adjusted_price(size)
+        last_price = self._last_price(symbol)
+        if np.isnan(last_price) and not (limit or stop):
+            # Only reachable in multi-asset mode, before the symbol's first bar
+            raise ValueError(
+                f'Cannot place a market order in {symbol!r}: no price data (yet) '
+                f'at {self._data.index[-1]}. A limit/stop order can be placed instead.')
+        adjusted_price = self._adjusted_price(size, last_price)
 
         if is_long:
             if not (sl or -np.inf) < (limit or stop or adjusted_price) < (tp or np.inf):
@@ -794,17 +972,19 @@ class _Broker:
                     "Short orders require: "
                     f"TP ({tp}) < LIMIT ({limit or stop or adjusted_price}) < SL ({sl})")
 
-        order = Order(self, size, limit, stop, sl, tp, trade, tag)
+        order = Order(self, size, limit, stop, sl, tp, trade, tag, symbol=symbol)
 
         if not trade:
             # If exclusive orders (each new order auto-closes previous orders/position),
-            # cancel all non-contingent orders and close all open trades beforehand
+            # cancel all non-contingent orders and close all open trades beforehand.
+            # In multi-asset mode, exclusivity applies per symbol.
             if self._exclusive_orders:
-                for o in self.orders:
-                    if not o.is_contingent:
+                for o in list(self.orders):
+                    if not o.is_contingent and o.symbol == symbol:
                         o.cancel()
-                for t in self.trades:
-                    t.close()
+                for t in list(self.trades):
+                    if t.symbol == symbol:
+                        t.close()
 
         # Put the new order in the order queue, Ensure SL orders are processed first
         self.orders.insert(0 if trade and stop else len(self.orders), order)
@@ -814,7 +994,16 @@ class _Broker:
     @property
     def last_price(self) -> float:
         """ Price at the last (current) close. """
-        return self._data.Close[-1]
+        return self._last_price(None)
+
+    def _last_price(self, symbol: Optional[str]) -> float:
+        """
+        `symbol`'s last valid close up to and including the current bar
+        (stale during multi-asset data gaps; NaN before the symbol's first bar).
+        """
+        if not self._symbols:
+            return self._data.Close[-1]
+        return self._last_close.get(symbol, np.nan)
 
     def _adjusted_price(self, size=None, price=None) -> float:
         """
@@ -835,6 +1024,10 @@ class _Broker:
 
     def next(self):
         i = self._i = len(self._data) - 1
+        for symbol in self._symbols:
+            close = self._data[symbol].Close[-1]
+            if close == close:  # Not NaN, i.e. the symbol trades on this bar
+                self._last_close[symbol] = close
         self._process_orders()
 
         # Log account equity for the equity curve
@@ -844,15 +1037,14 @@ class _Broker:
         # If equity is negative, set all to 0 and stop the simulation
         if equity <= 0:
             assert self.margin_available <= 0
-            for trade in self.trades:
-                self._close_trade(trade, self._data.Close[-1], i)
+            for trade in list(self.trades):
+                self._close_trade(trade, self._last_price(trade.symbol), i)
             self._cash = 0
             self._equity[i:] = 0
             raise _OutOfMoneyError
 
     def _process_orders(self):
         data = self._data
-        open, high, low = data.Open[-1], data.High[-1], data.Low[-1]
         reprocess_orders = False
 
         # Process orders
@@ -860,6 +1052,15 @@ class _Broker:
 
             # Related SL/TP order was already removed
             if order not in self.orders:
+                continue
+
+            # `data[None] is data`, so this is zero-cost in single-asset mode
+            d = data[order.symbol]
+            open, high, low = d.Open[-1], d.High[-1], d.Low[-1]
+            if np.isnan(open):
+                # No market in this symbol on this bar (multi-asset data gap).
+                # Order remains queued (Good 'Til Canceled) and can only fill
+                # at a price the symbol actually trades at.
                 continue
 
             # Check if stop condition was hit
@@ -890,20 +1091,24 @@ class _Broker:
                 price = (min(stop_price or open, order.limit)
                          if order.is_long else
                          max(stop_price or open, order.limit))
+                trade_on_prev_close = False
             else:
                 # Market-if-touched / market order
                 # Contingent orders always on next open
-                prev_close = data.Close[-2]
-                price = prev_close if self._trade_on_close and not order.is_contingent else open
+                prev_close = d.Close[-2]
+                # NaN prev_close means the order was deferred across a multi-asset
+                # data gap. Market orders never fill at prices the symbol isn't
+                # currently trading at, so fall back to filling at this
+                # (the symbol's first tradable) bar's open
+                trade_on_prev_close = (self._trade_on_close and not order.is_contingent and
+                                       not np.isnan(prev_close))
+                price = prev_close if trade_on_prev_close else open
                 if stop_price:
                     price = max(price, stop_price) if order.is_long else min(price, stop_price)
 
             # Determine entry/exit bar index
             is_market_order = not order.limit and not stop_price
-            time_index = (
-                (self._i - 1)
-                if is_market_order and self._trade_on_close and not order.is_contingent else
-                self._i)
+            time_index = (self._i - 1) if is_market_order and trade_on_prev_close else self._i
 
             # If order is a SL/TP order, it should close an existing trade it was contingent upon
             if order.parent_trade:
@@ -935,7 +1140,7 @@ class _Broker:
             # In long positions, the adjusted price is a fraction higher, and vice versa.
             adjusted_price = self._adjusted_price(order.size, price)
             adjusted_price_plus_commission = \
-                adjusted_price + self._commission(order.size, price) / abs(order.size)
+                adjusted_price + self._commission(order.size, price, order.symbol) / abs(order.size)
 
             # If order size was specified proportionally,
             # precompute true size in units, accounting for margin and spread/commissions
@@ -956,11 +1161,12 @@ class _Broker:
             need_size = int(size)
 
             if not self._hedging:
-                # Fill position by FIFO closing/reducing existing opposite-facing trades.
+                # Fill position by FIFO closing/reducing existing opposite-facing trades
+                # in the same symbol.
                 # Existing trades are closed at unadjusted price, because the adjustment
                 # was already made when buying.
                 for trade in list(self.trades):
-                    if trade.is_long == order.is_long:
+                    if trade.is_long == order.is_long or trade.symbol != order.symbol:
                         continue
                     assert trade.size * order.size < 0
 
@@ -995,7 +1201,8 @@ class _Broker:
                                  order.sl,
                                  order.tp,
                                  time_index,
-                                 order.tag)
+                                 order.tag,
+                                 order.symbol)
 
                 # We need to reprocess the SL/TP orders newly added to the queue.
                 # This allows e.g. SL hitting in the same bar the order was open.
@@ -1050,6 +1257,8 @@ class _Broker:
         self._close_trade(close_trade, price, time_index)
 
     def _close_trade(self, trade: Trade, price: float, time_index: int):
+        if price != price:  # Can't happen by construction; a NaN fill would poison the account
+            raise RuntimeError(f'Trade {trade} would close at a NaN price')
         self.trades.remove(trade)
         if trade._sl_order:
             self.orders.remove(trade._sl_order)
@@ -1059,25 +1268,100 @@ class _Broker:
         closed_trade = trade._replace(exit_price=price, exit_bar=time_index)
         self.closed_trades.append(closed_trade)
         # Apply commission one more time at trade exit
-        commission = self._commission(trade.size, price)
+        commission = self._commission(trade.size, price, trade.symbol)
         self._cash += trade.pl - commission
         # Save commissions on Trade instance for stats
-        trade_open_commission = self._commission(closed_trade.size, closed_trade.entry_price)
+        trade_open_commission = self._commission(
+            closed_trade.size, closed_trade.entry_price, trade.symbol)
         # applied here instead of on Trade open because size could have changed
         # by way of _reduce_trade()
         closed_trade._commissions = commission + trade_open_commission
 
     def _open_trade(self, price: float, size: int,
-                    sl: Optional[float], tp: Optional[float], time_index: int, tag):
-        trade = Trade(self, size, price, time_index, tag)
+                    sl: Optional[float], tp: Optional[float], time_index: int, tag,
+                    symbol: Optional[str] = None):
+        if price != price:  # Can't happen by construction; a NaN fill would poison the account
+            raise RuntimeError(f'Order in {symbol!r} would fill at a NaN price')
+        trade = Trade(self, size, price, time_index, tag, symbol=symbol)
         self.trades.append(trade)
         # Apply broker commission at trade open
-        self._cash -= self._commission(size, price)
+        self._cash -= self._commission(size, price, symbol)
         # Create SL/TP (bracket) orders.
         if tp:
             trade.tp = tp
         if sl:
             trade.sl = sl
+
+
+def _multiasset_df(data: Dict[str, pd.DataFrame]) -> pd.DataFrame:
+    """
+    Canonicalize a dict of per-symbol OHLC data frames into a single
+    two-level-column `(symbol, field)` data frame on the union of the
+    frames' indexes. Bars on which a symbol didn't trade become NaN rows
+    for that symbol; prices are never forward- or back-filled.
+    """
+    if not data:
+        raise ValueError('OHLC `data` is empty')
+    for symbol, df in data.items():
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError(f'data[{symbol!r}] must be a pandas.DataFrame with columns')
+        if not df.index.is_unique:
+            raise ValueError(f'data[{symbol!r}] index contains duplicate entries')
+    try:
+        return pd.concat(dict(data), axis=1)
+    except Exception as e:
+        raise ValueError(f'Failed to align `data` frames onto a union index: {e}') from e
+
+
+def _validate_multiasset_data(data: pd.DataFrame, cash: float) -> pd.DataFrame:
+    if data.columns.nlevels != 2:
+        raise ValueError('Multi-asset `data` columns must have exactly '
+                         'two levels: (symbol, field)')
+    data.columns = pd.MultiIndex.from_tuples(data.columns, names=('Symbol', None))
+    symbols = tuple(data.columns.get_level_values(0).unique())
+    if any(not isinstance(symbol, str) for symbol in symbols):
+        raise ValueError(f'Asset symbols must be strings; got: {symbols}')
+    shadowing = set(symbols) & {'Open', 'High', 'Low', 'Close', 'Volume'}
+    if shadowing:
+        raise ValueError(f'Asset symbols {sorted(shadowing)} would shadow '
+                         'OHLCV fields; rename them')
+    if len(data) == 0:
+        raise ValueError('OHLC `data` is empty')
+    if not data.index.is_unique:
+        raise ValueError('Data index contains duplicate entries')
+    if (data.index.dtype == object and
+            any(isinstance(value, pd.Timestamp) for value in data.index[:100])):
+        raise ValueError('Incompatible data indexes across symbols '
+                         '(mixing tz-aware and tz-naive timestamps?)')
+    for symbol in symbols:
+        missing = {'Open', 'High', 'Low', 'Close'} - set(data[symbol].columns)
+        if missing:
+            raise ValueError(f'data[{symbol!r}] is missing columns: {sorted(missing)}')
+        if (symbol, 'Volume') not in data.columns:
+            data[(symbol, 'Volume')] = np.nan
+        isna = data[symbol][['Open', 'High', 'Low', 'Close']].isnull()
+        if isna.values.all():
+            raise ValueError(f'data[{symbol!r}] contains no OHLC values')
+        partial = (isna.any(axis=1) & ~isna.all(axis=1)).values
+        if partial.any():
+            raise ValueError(
+                f'data[{symbol!r}] has bars with only some OHLC values missing (NaN), '
+                f'e.g. at {data.index[partial.argmax()]}. On each bar, a symbol\'s OHLC '
+                'values must either all be present (the symbol trades on that bar) '
+                'or all be missing (it does not).')
+    if np.any(data.xs('Close', axis=1, level=1) > cash):
+        warnings.warn('Some prices are larger than initial cash value. Note that fractional '
+                      'trading is not supported. If you want to trade Bitcoin, '
+                      'increase initial cash, or trade μBTC or satoshis instead.',
+                      stacklevel=3)
+    periods: List = [_data_period(data[symbol]['Close'].dropna().index)
+                     for symbol in symbols]
+    if try_(lambda: max(periods) / min(periods) > 2, False):
+        warnings.warn('Assets appear to trade on markedly different calendars/frequencies '
+                      f'(bar periods: {dict(zip(symbols, periods))}). Annualized statistics '
+                      'and Exposure Time are computed on the union of all timestamps '
+                      'and may be distorted.', stacklevel=3)
+    return data
 
 
 class Backtest:
@@ -1103,6 +1387,39 @@ class Backtest:
     DataFrame index can be either a datetime index (timestamps)
     or a monotonic range index (i.e. a sequence of periods).
 
+    .. tip:: Multi-asset (portfolio) backtesting
+        `data` can also be a **dict of such data frames, keyed by asset
+        symbol** (or, equivalently, one data frame with two-level
+        `(symbol, field)` columns), in which case the strategy trades a
+        portfolio of assets from a single account:
+
+            Backtest({'AAPL': aapl_df, 'MSFT': msft_df}, MyStrategy, cash=100_000)
+
+        In multi-asset mode:
+
+        * `Strategy.data` is accessed per symbol: `self.data[symbol].Close`,
+          with symbols listed in `self.data.symbols`. The data spans the
+          **union** of all assets' timestamps; bars on which an asset didn't
+          trade (a different calendar, a halt, or before/after its listing)
+          hold NaN, and prices are never forward- or back-filled.
+        * Orders are routed with `Strategy.buy(symbol=...)` /
+          `Strategy.sell(symbol=...)` and positions are queried with
+          `Strategy.positions[symbol]`. On bars where a symbol doesn't trade,
+          its pending orders simply wait (Good 'Til Canceled): market orders
+          fill at the symbol's next traded bar's open, and limit/stop/SL/TP
+          conditions are only ever evaluated against traded bars.
+        * Cash, equity and margin form a **single shared account**;
+          open trades are marked to market at each symbol's most recent
+          traded close. `hedging` and `exclusive_orders` apply per symbol.
+        * `Strategy.I` indicators can be associated with a symbol via
+          `self.I(..., symbol=...)`, which groups them for warm-up
+          (the backtest starts when the earliest-ready symbol's indicators
+          are non-NaN) and attributes them to that symbol's chart in
+          `Backtest.plot(symbol=...)`.
+        * In computed statistics, 'Buy & Hold Return [%]' and the Alpha/Beta
+          benchmark refer to an equal-weighted, per-bar-rebalanced basket
+          of all assets, and `stats['_trades']` gains a 'Symbol' column.
+
     `strategy` is a `backtesting.backtesting.Strategy`
     _subclass_ (not an instance).
 
@@ -1122,6 +1439,10 @@ class Backtest:
     `func(order_size: int, price: float) -> float`
     (note, order size is negative for short orders),
     which can be used to model more complex commission structures.
+    In a multi-asset backtest, a callable that declares a third
+    parameter named `symbol` (or three required positional parameters)
+    is called as `func(order_size, price, symbol)`, allowing
+    per-asset fee schedules.
     Negative commission values are interpreted as market-maker's rebates.
 
     .. note::
@@ -1155,7 +1476,10 @@ class Backtest:
 
     If `finalize_trades` is `True`, the trades that are still
     [active and ongoing] at the end of the backtest will be closed on
-    the last bar and will contribute to the computed backtest statistics.
+    the last bar and will contribute to the computed backtest statistics
+    (in a multi-asset backtest, trades in a symbol with no bar on the final
+    timestamp are instead settled at the symbol's own last traded close,
+    on its last traded bar).
 
     .. tip:: Fractional trading
         See also `backtesting.lib.FractionalBacktest` if you want to trade
@@ -1179,8 +1503,11 @@ class Backtest:
                  ):
         if not (isinstance(strategy, type) and issubclass(strategy, Strategy)):
             raise TypeError('`strategy` must be a Strategy sub-type')
+        if isinstance(data, dict):
+            data = _multiasset_df(data)
         if not isinstance(data, pd.DataFrame):
-            raise TypeError("`data` must be a pandas.DataFrame with columns")
+            raise TypeError("`data` must be a pandas.DataFrame with columns, "
+                            "or a dict of such data frames keyed by asset symbol")
         if not isinstance(spread, Number):
             raise TypeError('`spread` must be a float value, percent of '
                             'entry order price')
@@ -1203,24 +1530,27 @@ class Backtest:
             except ValueError:
                 pass
 
-        if 'Volume' not in data:
-            data['Volume'] = np.nan
+        if isinstance(data.columns, pd.MultiIndex):
+            data = _validate_multiasset_data(data, cash)
+        else:
+            if 'Volume' not in data:
+                data['Volume'] = np.nan
 
-        if len(data) == 0:
-            raise ValueError('OHLC `data` is empty')
-        if len(data.columns.intersection({'Open', 'High', 'Low', 'Close', 'Volume'})) != 5:
-            raise ValueError("`data` must be a pandas.DataFrame with columns "
-                             "'Open', 'High', 'Low', 'Close', and (optionally) 'Volume'")
-        if data[['Open', 'High', 'Low', 'Close']].isnull().values.any():
-            raise ValueError('Some OHLC values are missing (NaN). '
-                             'Please strip those lines with `df.dropna()` or '
-                             'fill them in with `df.interpolate()` or whatever.')
-        if np.any(data['Close'] > cash):
-            warnings.warn('Some prices are larger than initial cash value. Note that fractional '
-                          'trading is not supported by this class. If you want to trade Bitcoin, '
-                          'increase initial cash, or trade μBTC or satoshis instead (see e.g. class '
-                          '`backtesting.lib.FractionalBacktest`.',
-                          stacklevel=2)
+            if len(data) == 0:
+                raise ValueError('OHLC `data` is empty')
+            if len(data.columns.intersection({'Open', 'High', 'Low', 'Close', 'Volume'})) != 5:
+                raise ValueError("`data` must be a pandas.DataFrame with columns "
+                                 "'Open', 'High', 'Low', 'Close', and (optionally) 'Volume'")
+            if data[['Open', 'High', 'Low', 'Close']].isnull().values.any():
+                raise ValueError('Some OHLC values are missing (NaN). '
+                                 'Please strip those lines with `df.dropna()` or '
+                                 'fill them in with `df.interpolate()` or whatever.')
+            if np.any(data['Close'] > cash):
+                warnings.warn('Some prices are larger than initial cash value. Note that fractional '
+                              'trading is not supported by this class. If you want to trade Bitcoin, '
+                              'increase initial cash, or trade μBTC or satoshis instead (see e.g. class '
+                              '`backtesting.lib.FractionalBacktest`.',
+                              stacklevel=2)
         if not data.index.is_monotonic_increasing:
             warnings.warn('Data index is not sorted in ascending order. Sorting.',
                           stacklevel=2)
@@ -1294,27 +1624,32 @@ class Backtest:
         broker: _Broker = self._broker(data=data)
         strategy: Strategy = self._strategy(broker, data, kwargs)
 
-        strategy.init()
-        data._update()  # Strategy.init might have changed/added to data.df
-
-        # Indicators used in Strategy.next()
-        indicator_attrs = _strategy_indicators(strategy)
-
-        # Skip first few candles where indicators are still "warming up"
-        # +1 to have at least two entries available
-        start = 1 + _indicator_warmup_nbars(strategy)
-
         # Disable "invalid value encountered in ..." warnings. Comparison
         # np.nan >= 3 is not invalid; it's False.
         with np.errstate(invalid='ignore'):
+
+            strategy.init()
+            data._update()  # Strategy.init might have changed/added to data.df
+
+            # Indicators used in Strategy.next()
+            indicator_attrs = _strategy_indicators(strategy)
+
+            # Skip first few candles where indicators are still "warming up"
+            # +1 to have at least two entries available
+            start = 1 + _indicator_warmup_nbars(strategy)
+            if start > len(self._data):
+                # Only reachable in multi-asset mode (all-NaN indicators)
+                warnings.warn(
+                    'No indicator (symbol group) ever becomes non-NaN; '
+                    'no trading will be simulated.', stacklevel=2)
 
             for i in _tqdm(range(start, len(self._data)), desc=self.run.__qualname__,
                            unit='bar', mininterval=2, miniters=100):
                 # Prepare data and indicators for `next` call
                 data._set_length(i + 1)
                 for attr, indicator in indicator_attrs:
-                    # Slice indicator on the last dimension (case of 2d indicator)
-                    setattr(strategy, attr, indicator[..., :i + 1])
+                    # Slice indicator(s) on the last dimension (case of 2d indicator)
+                    setattr(strategy, attr, _indicator_sliced(indicator, i + 1))
 
                 # Handle orders processing and broker stuff
                 try:
@@ -1334,11 +1669,34 @@ class Backtest:
                     #  strategy iteration. Use the same OHLC values as in the last broker iteration.
                     if start < len(self._data):
                         try_(broker.next, exception=_OutOfMoneyError)
+
+                    # In multi-asset mode, trades whose symbol has no bar on the final
+                    # (union) timestamp can't close through the order pipeline above;
+                    # settle them at the symbol's last traded close, on its last traded bar
+                    settled = [trade for trade in broker.trades
+                               if np.isnan(data[trade.symbol].Close[-1])]
+                    for trade in settled:
+                        close = np.asarray(data[trade.symbol].Close, dtype=float)
+                        exit_bar = int(np.flatnonzero(~np.isnan(close))[-1])
+                        broker._close_trade(trade, broker._last_price(trade.symbol), exit_bar)
+                    if settled:
+                        settled_set = set(map(id, settled))
+                        broker.orders[:] = [
+                            order for order in broker.orders
+                            if id(order.parent_trade) not in settled_set]
+                        # Settlement commissions hit cash after the last equity
+                        # sample was recorded; restate it
+                        broker._equity[len(self._data) - 1] = broker.equity
                 elif len(broker.trades):
+                    open_symbols = sorted(
+                        symbol for symbol in {t.symbol for t in broker.trades}
+                        if symbol is not None)
                     warnings.warn(
                         'Some trades remain open at the end of backtest. Use '
                         '`Backtest(..., finalize_trades=True)` to close them and '
-                        'include them in stats.', stacklevel=2)
+                        'include them in stats.' +
+                        (f' Open trades in symbols: {open_symbols}.' if open_symbols else ''),
+                        stacklevel=2)
 
             # Set data back to full length
             # for future `indicator._opts['data'].index` calls to work
@@ -1633,7 +1991,8 @@ class Backtest:
              smooth_equity=False, relative_equity=True,
              superimpose: Union[bool, str] = True,
              resample=True, reverse_indicators=False,
-             show_legend=True, open_browser=True):
+             show_legend=True, open_browser=True,
+             symbol: Optional[str] = None):
         """
         Plot the progression of the last backtest run.
 
@@ -1642,6 +2001,12 @@ class Backtest:
         `backtesting.backtesting.Backtest.run` or
         `backtesting.backtesting.Backtest.optimize`, otherwise the last
         run's results are used.
+
+        In a multi-asset backtest, `symbol` selects which asset's chart
+        to plot (candlesticks on the bars the symbol actually traded,
+        along with the symbol's trades and associated indicators).
+        The equity/drawdown sections show the whole account, sampled at
+        the symbol's bars; refer to the stats for exact account extremes.
 
         `filename` is the path to save the interactive HTML plot to.
         By default, a strategy/parameter-dependent file is created in the
@@ -1718,10 +2083,46 @@ class Backtest:
                 raise RuntimeError('First issue `backtest.run()` to obtain results.')
             results = self._results
 
+        df = self._data
+        indicators = results._strategy._indicators
+        if not isinstance(df.columns, pd.MultiIndex):
+            if symbol is not None:
+                raise ValueError('`symbol=` is only valid in multi-asset mode')
+        else:
+            symbols = tuple(df.columns.get_level_values(0).unique())
+            if symbol is None:
+                raise ValueError(f'Multi-asset backtest: pass `plot(symbol=...)` '
+                                 f'to select the chart to plot. Symbols: {symbols}')
+            if symbol not in symbols:
+                raise ValueError(f'Unknown symbol {symbol!r}; symbols: {symbols}')
+            # Project results onto the bars the symbol actually traded
+            mask = df[(symbol, 'Close')].notna().values
+            valid = np.flatnonzero(mask)
+            df = df[symbol][mask]
+            trades = results['_trades']
+            trades = trades[trades['Symbol'] == symbol].copy()
+            # Every fill lands on a traded bar of its symbol by construction;
+            # `side='right') - 1` also clamps the one exception (bankruptcy
+            # liquidation during a data gap) to the symbol's last prior bar
+            trades[['EntryBar', 'ExitBar']] = (
+                np.searchsorted(valid, trades[['EntryBar', 'ExitBar']], side='right') - 1)
+            results = results.copy()
+            results['_trades'] = trades
+            results['_equity_curve'] = results['_equity_curve'][mask]
+            indicators = [_Indicator(np.asarray(indicator)[..., mask],
+                                     **dict(indicator._opts, name=indicator.name,
+                                            index=df.index))
+                          for indicator in indicators
+                          if indicator._opts.get('symbol') in (None, symbol)]
+            if not filename:
+                from ._plotting import IS_JUPYTER_NOTEBOOK, _windos_safe_filename
+                if not IS_JUPYTER_NOTEBOOK:
+                    filename = _windos_safe_filename(f'{results._strategy}-{symbol}')
+
         return plot(
             results=results,
-            df=self._data,
-            indicators=results._strategy._indicators,
+            df=df,
+            indicators=indicators,
             filename=filename,
             plot_width=plot_width,
             plot_equity=plot_equity,

--- a/backtesting/lib.py
+++ b/backtesting/lib.py
@@ -376,6 +376,7 @@ class SignalStrategy(Strategy):
     """
     A simple helper strategy that operates on position entry/exit signals.
     This makes the backtest of the strategy simulate a [vectorized backtest].
+    Single-asset only.
     See [tutorials] for usage examples.
 
     [vectorized backtest]: https://www.google.com/search?q=vectorized+backtest
@@ -449,7 +450,7 @@ class TrailingStrategy(Strategy):
     A strategy with automatic trailing stop-loss, trailing the current
     price at distance of some multiple of average true range (ATR). Call
     `TrailingStrategy.set_trailing_sl()` to set said multiple
-    (`6` by default). See [tutorials] for usage examples.
+    (`6` by default). Single-asset only. See [tutorials] for usage examples.
 
     [tutorials]: index.html#tutorials
 
@@ -527,6 +528,8 @@ class FractionalBacktest(Backtest):
                  *args,
                  fractional_unit=1 / 100e6,
                  **kwargs):
+        if isinstance(data, dict) or isinstance(getattr(data, 'columns', None), pd.MultiIndex):
+            raise TypeError('FractionalBacktest is single-asset only')
         if 'satoshi' in kwargs:
             warnings.warn(
                 'Parameter `FractionalBacktest(..., satoshi=)` is deprecated. '
@@ -571,7 +574,10 @@ class MultiBacktest:
 
     Run supplied `backtesting.backtesting.Strategy` on several instruments,
     in parallel.  Used for comparing strategy runs across many instruments
-    or classes of instruments. Example:
+    or classes of instruments. Note, these are **independent single-asset
+    backtests**, each with its own account; for trading a portfolio of
+    assets from one shared account, pass a dict of data frames to
+    `backtesting.backtesting.Backtest` instead. Example:
 
         from backtesting.test import EURUSD, BTCUSD, SmaCross
         btm = MultiBacktest([EURUSD, BTCUSD], SmaCross)

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import unittest
+import warnings
 from concurrent.futures.process import ProcessPoolExecutor
 from contextlib import contextmanager
 from glob import glob
@@ -1177,3 +1178,908 @@ class TestRegressions(TestCase):
         trades = Backtest(SHORT_DATA, S).run()._trades
         self.assertEqual(trades['SL'].fillna(0).tolist(), [0, 99])
         self.assertEqual(trades['TP'].fillna(0).tolist(), [111, 0])
+
+
+class TestMultiAsset(TestCase):
+    @staticmethod
+    def _df(values, index=None, high=None, low=None):
+        """OHLC frame with Open == Close (== High == Low unless overridden).
+        NaN values produce all-NaN (non-traded) bars."""
+        v = pd.Series(values, index=index, dtype=float)
+        return pd.DataFrame({
+            'Open': v,
+            'High': v if high is None else pd.Series(high, index=index, dtype=float),
+            'Low': v if low is None else pd.Series(low, index=index, dtype=float),
+            'Close': v})
+
+    @staticmethod
+    def _index(n, start='2020-01-01'):
+        return pd.date_range(start, periods=n, freq='D')
+
+    @contextmanager
+    def _no_full_equity_warning(self):
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', message='.*default size.*')
+            yield
+
+    # Input handling & validation ############################################
+
+    def test_dict_and_multiindex_input_equivalent(self):
+        a, b = GOOG.iloc[:60], GOOG.iloc[30:90] * 2
+        multi_df = pd.concat({'A': a, 'B': b}, axis=1)
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 40:
+                    self.buy(symbol='A', size=1)
+                    self.sell(symbol='B', size=1)
+
+        stats1 = Backtest({'A': a, 'B': b}, S, finalize_trades=True).run()
+        stats2 = Backtest(multi_df, S, finalize_trades=True).run()
+        assert_frame_equal(stats1._trades, stats2._trades)
+        np.testing.assert_array_equal(stats1._equity_curve.Equity,
+                                      stats2._equity_curve.Equity)
+        self.assertEqual(sorted(stats1._trades['Symbol']), ['A', 'B'])
+        self.assertEqual(stats1._trades.columns[0], 'Symbol')
+
+    def test_single_asset_has_no_symbol_column(self):
+        stats = Backtest(SHORT_DATA, SmaCross, finalize_trades=True).run(fast=2, slow=4)
+        self.assertNotIn('Symbol', stats._trades.columns)
+
+    def test_input_validation(self):
+        idx = self._index(4)
+        good = self._df([1, 2, 3, 4], idx)
+
+        # Non-DataFrame dict value
+        self.assertRaises(TypeError, Backtest, {'A': good.Close}, _S)
+        # Empty dict
+        self.assertRaises(ValueError, Backtest, {}, _S)
+        # Duplicate timestamps within a symbol
+        dup = good.copy()
+        dup.index = idx[[0, 1, 1, 2]]
+        self.assertRaises(ValueError, Backtest, {'A': dup}, _S)
+        # Non-string symbols
+        self.assertRaises(ValueError, Backtest, {1: good}, _S)
+        # Symbol shadowing OHLCV fields
+        self.assertRaises(ValueError, Backtest, {'Close': good}, _S)
+        # Partially-NaN OHLC bar
+        partial = good.copy()
+        partial.loc[idx[1], 'High'] = np.nan
+        self.assertRaisesRegex(ValueError, 'all be present',
+                               Backtest, {'A': good, 'B': partial}, _S)
+        # All-NaN symbol
+        self.assertRaisesRegex(ValueError, 'no OHLC',
+                               Backtest, {'A': good, 'B': good * np.nan}, _S)
+        # >2 column levels
+        deep = pd.concat({'X': pd.concat({'A': good}, axis=1)}, axis=1)
+        self.assertRaises(ValueError, Backtest, deep, _S)
+        # Mixed tz-aware and tz-naive indexes
+        tz = good.copy()
+        tz.index = tz.index.tz_localize('UTC')
+        self.assertRaises(ValueError, Backtest, {'A': good, 'B': tz}, _S)
+        # Volume is added per symbol
+        bt = Backtest({'A': good, 'B': good}, _S)
+        self.assertIn(('A', 'Volume'), bt._data.columns)
+        self.assertIn(('B', 'Volume'), bt._data.columns)
+        # Warning on prices exceeding cash
+        with self.assertWarnsRegex(UserWarning, 'larger than initial cash'):
+            Backtest({'A': good, 'B': good * 1e6}, _S)
+        # Warning on markedly different calendars
+        monthly = self._df(np.r_[1:5], pd.date_range('2020-01-01', periods=4, freq='MS'))
+        with self.assertWarnsRegex(UserWarning, 'calendars'):
+            Backtest({'A': good, 'B': monthly}, _S)
+
+    def test_symbol_validation_and_suggestions(self):
+        class BuyTypo(_S):
+            def next(self):
+                self.buy(symbol='GOOX')
+
+        bt = Backtest({'GOOG': SHORT_DATA, 'AAPL': SHORT_DATA}, BuyTypo)
+        self.assertRaisesRegex(ValueError, "Did you mean: 'GOOG'", bt.run)
+
+        class BuyNoSymbol(_S):
+            def next(self):
+                self.buy()
+
+        bt = Backtest({'GOOG': SHORT_DATA, 'AAPL': SHORT_DATA}, BuyNoSymbol)
+        self.assertRaisesRegex(ValueError, 'explicit order routing', bt.run)
+
+        class SymbolInSingle(_S):
+            def next(self):
+                self.buy(symbol='GOOG')
+
+        bt = Backtest(SHORT_DATA, SymbolInSingle)
+        self.assertRaisesRegex(ValueError, 'single-asset backtest', bt.run)
+
+        class BadIndicatorSymbol(_S):
+            def init(self):
+                self.I(SMA, self.data['GOOG'].Close, 2, symbol='NOPE')
+
+            def next(self):
+                pass
+
+        bt = Backtest({'GOOG': SHORT_DATA, 'AAPL': SHORT_DATA}, BadIndicatorSymbol)
+        self.assertRaisesRegex(ValueError, 'Unknown symbol', bt.run)
+
+    # Zero-behavior-change degeneracy ########################################
+
+    def test_degeneracy_matrix(self):
+        """`Backtest({'X': df})` must equal `Backtest(df)` bit for bit."""
+        class SmaCrossM(Strategy):
+            fast, slow = 10, 30
+
+            def init(self):
+                close = self.data['X'].Close
+                self.sma1 = self.I(SMA, close, self.fast, symbol='X')
+                self.sma2 = self.I(SMA, close, self.slow, symbol='X')
+
+            def next(self):
+                if crossover(self.sma1, self.sma2):
+                    self.positions['X'].close()
+                    self.buy(symbol='X')
+                elif crossover(self.sma2, self.sma1):
+                    self.positions['X'].close()
+                    self.sell(symbol='X')
+
+        df = GOOG.iloc[:150]
+        for kwargs in (dict(),
+                       dict(trade_on_close=True),
+                       dict(hedging=True),
+                       dict(exclusive_orders=True),
+                       dict(margin=.1, spread=.001, commission=.002),
+                       dict(finalize_trades=True),
+                       dict(finalize_trades=True, trade_on_close=True)):
+            with self.subTest(**kwargs):
+                stats1 = Backtest(df, SmaCross, **kwargs).run()
+                with self._no_full_equity_warning():
+                    stats2 = Backtest({'X': df}, SmaCrossM, **kwargs).run()
+                np.testing.assert_array_equal(stats1._equity_curve.Equity,
+                                              stats2._equity_curve.Equity)
+                trades2 = stats2._trades.drop(columns='Symbol')
+                trades1 = stats1._trades
+                # Indicator entry/exit column names differ ('X: SMA...'); compare values
+                trades2.columns = trades1.columns
+                assert_frame_equal(trades1, trades2)
+
+    # Look-ahead bias ########################################################
+
+    def test_progressive_revelation(self):
+        idx = self._index(30)
+        a = self._df(np.r_[1:31.], idx)
+        b = self._df(np.r_[[np.nan] * 10, 11:31.], idx)  # Lists 10 bars later
+        test = self
+
+        class S(_S):
+            def init(self):
+                self.a = self.data['A']  # Child view captured in init
+                self.data.df[('A', 'Extra')] = np.arange(30.)  # Mutate master df
+
+            def next(self):
+                i = len(self.data)
+                test.assertEqual(len(self.data['A']), i)
+                test.assertEqual(len(self.data['B']), i)
+                test.assertEqual(len(self.a), i)  # Captured view stays slaved
+                test.assertEqual(self.a.Close[-1], i)
+                test.assertEqual(len(self.data.df), i)
+                test.assertEqual(self.data['A'].Extra[-1], i - 1)
+                b_close = self.data['B'].Close
+                if i <= 10:
+                    test.assertTrue(np.isnan(b_close[-1]))  # Pre-listing NaN
+                else:
+                    test.assertEqual(b_close[-1], i)
+                test.assertEqual(self.data.index[-1], idx[i - 1])
+
+        Backtest({'A': a, 'B': b}, S).run()
+
+    def test_future_perturbation_does_not_change_past(self):
+        T = 100
+        rng = np.random.RandomState(0)
+
+        def perturbed(df, t):
+            df = df.copy()
+            noise = 1 + .2 * rng.random(len(df) - t)
+            for col in ('Open', 'High', 'Low', 'Close'):
+                df.iloc[t:, df.columns.get_loc(col)] *= noise
+            return df
+
+        a, b = GOOG.iloc[:150], GOOG.iloc[20:170].reset_index(drop=True).set_index(
+            GOOG.index[:150]) * 1.5
+
+        class S(Strategy):
+            def init(self):
+                self.sma = {s: self.I(SMA, self.data[s].Close, 10, symbol=s)
+                            for s in self.data.symbols}
+
+            def next(self):
+                for s in self.data.symbols:
+                    if crossover(self.data[s].Close, self.sma[s]):
+                        self.buy(symbol=s, size=.2)
+                    elif self.positions[s] and crossover(self.sma[s], self.data[s].Close):
+                        self.positions[s].close()
+
+        stats1 = Backtest({'A': a, 'B': b}, S).run()
+        stats2 = Backtest({'A': perturbed(a, T), 'B': perturbed(b, T)}, S).run()
+
+        np.testing.assert_array_equal(stats1._equity_curve.Equity[:T],
+                                      stats2._equity_curve.Equity[:T])
+        closed_before_t = [t[t.ExitBar < T] for t in (stats1._trades, stats2._trades)]
+        assert_frame_equal(*closed_before_t)
+        self.assertGreater(len(closed_before_t[0]), 0)
+
+    # NaN-gap (calendar) semantics ###########################################
+
+    def test_market_order_defers_across_gap(self):
+        idx = self._index(6)
+        a = self._df([10, 11, 12, 13, 14, 15], idx)
+        b = self._df([20, 21, np.nan, np.nan, 24, 25], idx)
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='B', size=1)
+
+        stats = Backtest({'A': a, 'B': b}, S, finalize_trades=True).run()
+        trade = stats._trades.iloc[0]
+        # Order placed on bar 1 fills at B's next traded bar's open (bar 4 @ 24),
+        # not on NaN bars 2-3, not at a stale/ffilled price
+        self.assertEqual(trade.EntryBar, 4)
+        self.assertEqual(trade.EntryPrice, 24)
+        self.assertEqual(trade.EntryTime, idx[4])
+
+    def test_contingent_orders_dormant_during_gap(self):
+        idx = self._index(7)
+        a = self._df([10, 11, 12, 13, 14, 15, 16], idx)
+        # B: trades at 20, 21, then halts (during which "prices" would have crossed
+        # any level), resumes at 15 (gapping through the stop level 18)
+        b = self._df([20, 21, np.nan, np.nan, np.nan, 15, 15], idx)
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.sell(symbol='B', size=1, stop=18)
+
+        stats = Backtest({'A': a, 'B': b}, S, finalize_trades=True).run()
+        trade = stats._trades.iloc[0]
+        # Stop not evaluated during the halt; on resume, pessimistic gap-through
+        # fill at min(open, stop) = 15
+        self.assertEqual(trade.EntryBar, 5)
+        self.assertEqual(trade.EntryPrice, 15)
+
+        class S2(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='B', size=1, sl=19)
+
+        stats2 = Backtest({'A': a, 'B': b}, S2).run()
+        trade2 = stats2._trades.iloc[0]
+        # Entry at bar 2's open is deferred to bar 5 (B halted); SL 19 then
+        # exits at min(open, sl) = 15 on B's next traded bar
+        self.assertEqual((trade2.EntryBar, trade2.EntryPrice), (5, 15))
+
+    def test_trade_on_close_across_gap(self):
+        idx = self._index(6)
+        a = self._df([10, 11, 12, 13, 14, 15], idx)
+        b = self._df([20, 21, np.nan, np.nan, 24, 25], idx)
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=1)  # Contiguous symbol
+                    self.buy(symbol='B', size=1)  # Symbol halted on next bar
+
+        with self._no_full_equity_warning():
+            stats = Backtest({'A': a, 'B': b}, S, trade_on_close=True,
+                             finalize_trades=True).run()
+        trades = stats._trades.set_index('Symbol')
+        # A fills at bar 1's close, stamped on bar 1 (standard trade_on_close)
+        self.assertEqual((trades.loc['A', 'EntryBar'], trades.loc['A', 'EntryPrice']), (1, 11))
+        # B, deferred across the gap, fills at its resume bar's open --
+        # there was no close it could have filled at
+        self.assertEqual((trades.loc['B', 'EntryBar'], trades.loc['B', 'EntryPrice']), (4, 24))
+
+    def test_mark_to_market_and_equity_during_halt(self):
+        idx = self._index(6)
+        a = self._df([10.] * 6, idx)  # Flat, to isolate B's effect
+        b = self._df([20, 21, np.nan, np.nan, 27, 28], idx)
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='B', size=2)
+
+        stats = Backtest({'A': a, 'B': b}, S, cash=1000, finalize_trades=True).run()
+        equity = stats._equity_curve.Equity
+        # Entry (ordered on bar 1) is deferred over the bar-2/3 halt to bar 4 @ 27
+        trade = stats._trades.iloc[0]
+        self.assertEqual((trade.EntryBar, trade.EntryPrice), (4, 27))
+        np.testing.assert_array_equal(equity.values, [
+            1000, 1000, 1000, 1000, 1000, 1000 + 2 * (28 - 27)])
+
+    def test_mark_to_market_stale_close(self):
+        idx = self._index(6)
+        a = self._df([10.] * 6, idx)
+        b = self._df([20, 21, 22, np.nan, np.nan, 30], idx)
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='B', size=2)
+
+        with self.assertWarnsRegex(UserWarning, 'remain open.*B'):
+            stats = Backtest({'A': a, 'B': b}, S, cash=1000).run()
+        equity = stats._equity_curve.Equity
+        # Entry bar 2 @ 22; equity marks at 22 through the bar-3/4 halt
+        np.testing.assert_array_equal(equity.values, [
+            1000, 1000, 1000, 1000, 1000, 1000 + 2 * (30 - 22)])
+
+    def test_pre_listing_orders(self):
+        idx = self._index(5)
+        a = self._df([10, 11, 12, 13, 14], idx)
+        b = self._df([np.nan, np.nan, 20, 21, 22], idx)
+
+        class MarketTooEarly(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='B', size=1)
+
+        bt = Backtest({'A': a, 'B': b}, MarketTooEarly)
+        self.assertRaisesRegex(ValueError, 'no price data', bt.run)
+
+        class LimitBeforeListing(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='B', size=1, limit=20.5)
+
+        stats = Backtest({'A': a, 'B': b}, LimitBeforeListing, finalize_trades=True).run()
+        trade = stats._trades.iloc[0]
+        # Limit order legally queues pre-listing and fills once B lists
+        self.assertEqual((trade.EntryBar, trade.EntryPrice), (2, 20))
+
+    # Netting, hedging, exclusivity, margin ##################################
+
+    def test_netting_scoped_per_symbol(self):
+        idx = self._index(6)
+        dfs = {s: self._df([10, 11, 12, 13, 14, 15], idx) for s in 'AB'}
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=5)
+                    self.buy(symbol='B', size=3)
+                elif len(self.data) == 4:
+                    self.sell(symbol='A', size=2)  # Reduces A only
+
+        stats = Backtest(dfs, S).run()
+        # The sell(2) FIFO-reduced A's own position; B untouched
+        closed, = stats._trades.itertuples(index=False)
+        self.assertEqual((closed.Symbol, closed.Size), ('A', 2))
+        remaining = {t.symbol: t.size for t in stats._strategy._broker.trades}
+        self.assertEqual(remaining, {'A': 3, 'B': 3})
+
+    def test_exclusive_orders_scoped_per_symbol(self):
+        idx = self._index(6)
+        dfs = {s: self._df([10, 11, 12, 13, 14, 15], idx) for s in 'AB'}
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=1)
+                    self.buy(symbol='B', size=1)
+                elif len(self.data) == 4:
+                    self.sell(symbol='A', size=1)  # Flips A; must not touch B
+
+        stats = Backtest(dfs, S, exclusive_orders=True).run()
+        remaining = {t.symbol: t.size for t in stats._strategy._broker.trades}
+        self.assertEqual(remaining, {'A': -1, 'B': 1})
+        closed = stats._trades
+        self.assertEqual(list(closed.Symbol), ['A'])
+
+    def test_hedging_across_symbols(self):
+        idx = self._index(4)
+        dfs = {s: self._df([10, 11, 12, 13], idx) for s in 'AB'}
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=1)
+                    self.sell(symbol='B', size=1)
+
+        stats = Backtest(dfs, S, hedging=True).run()
+        remaining = {t.symbol: t.size for t in stats._strategy._broker.trades}
+        self.assertEqual(remaining, {'A': 1, 'B': -1})
+
+    def test_shared_account_margin(self):
+        idx = self._index(4)
+        dfs = {s: self._df([100.] * 4, idx) for s in 'AB'}
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=.5)
+                    self.buy(symbol='B', size=.5)
+
+        stats = Backtest(dfs, S, cash=1000).run()
+        trades = stats._strategy._broker.trades
+        # Sequential consumption of one shared account: .5 *of remaining* each
+        self.assertEqual([(t.symbol, t.size) for t in trades], [('A', 5), ('B', 2)])
+
+        class TooBig(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=9)
+                    self.buy(symbol='B', size=9)
+
+        with self.assertWarnsRegex(UserWarning, 'insufficient margin'):
+            Backtest(dfs, TooBig, cash=1000).run()
+
+    def test_full_equity_default_size_warns_once(self):
+        idx = self._index(4)
+        dfs = {s: self._df([10, 11, 12, 13], idx) for s in 'AB'}
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A')
+                    self.buy(symbol='B')
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter('always')
+            Backtest(dfs, S).run()
+        self.assertEqual(sum('default size' in str(x.message) for x in w), 1)
+
+    def test_bankruptcy_closes_all_positions(self):
+        idx = self._index(5)
+        a = self._df([100, 100, 50, 10, 5], idx)
+        b = self._df([100, 100, 60, 20, 10], idx)
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=12)
+                    self.buy(symbol='B', size=12)
+
+        stats = Backtest({'A': a, 'B': b}, S, cash=1000, margin=.5).run()
+        self.assertEqual(len(stats._strategy._broker.trades), 0)
+        self.assertEqual(sorted(stats._trades.Symbol), ['A', 'B'])
+        equity = stats._equity_curve.Equity
+        self.assertEqual(equity.iloc[-1], 0)
+
+    # Positions & data API ###################################################
+
+    def test_positions_api(self):
+        idx = self._index(5)
+        dfs = {s: self._df([10, 11, 12, 13, 14], idx) for s in 'AB'}
+        test = self
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=2)
+                if len(self.data) == 4:
+                    test.assertTrue(self.positions['A'])
+                    test.assertFalse(self.positions['B'])
+                    test.assertEqual(self.positions['A'].size, 2)
+                    test.assertEqual(self.positions['A'].symbol, 'A')
+                    test.assertGreater(self.positions['A'].pl, 0)
+                    test.assertRaises(RuntimeError, lambda: self.position)
+                    test.assertRaises(KeyError, lambda: self.positions['Z'])
+                    test.assertRaisesRegex(
+                        AttributeError, 'ambiguous', lambda: self.data.Close)
+                    test.assertRaisesRegex(
+                        AttributeError, 'ambiguous', lambda: self.data.pip)
+                    test.assertEqual(self.data['A'].pip, .1)
+                    self.positions['A'].close()
+
+        Backtest(dfs, S).run()
+
+    def test_portable_strategy_idiom(self):
+        class Portable(Strategy):
+            def init(self):
+                self.sma = {s: self.I(SMA, self.data[s].Close, 3, symbol=s)
+                            for s in (self.data.symbols or (None,))}
+
+            def next(self):
+                for s in (self.data.symbols or (None,)):
+                    d = self.data[s]
+                    if np.isnan(d.Close[-1]):
+                        continue
+                    if not self.positions[s] and d.Close[-1] > self.sma[s][-1]:
+                        self.buy(symbol=s, size=1)
+                    elif self.positions[s] and d.Close[-1] < self.sma[s][-1]:
+                        self.positions[s].close()
+
+        stats_single = Backtest(SHORT_DATA, Portable).run()
+        stats_multi = Backtest({'X': SHORT_DATA, 'Y': SHORT_DATA * 2}, Portable).run()
+        self.assertGreater(stats_single['# Trades'], 0)
+        self.assertGreater(stats_multi['# Trades'], 0)
+
+    def test_order_trade_symbol_attribution(self):
+        idx = self._index(5)
+        dfs = {s: self._df([10, 11, 12, 13, 14], idx) for s in 'AB'}
+        test = self
+        commission_symbols = []
+
+        def commission(order_size, price, symbol):
+            commission_symbols.append(symbol)
+            return 0.
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    order = self.buy(symbol='A', size=2, sl=5, tp=100)
+                    test.assertEqual(order.symbol, 'A')
+                    test.assertIn("symbol='A'", repr(order))
+                if len(self.data) == 4:
+                    trade, = self.trades
+                    test.assertEqual(trade.symbol, 'A')
+                    test.assertIn('symbol=A', repr(trade))
+                    test.assertEqual(trade._sl_order.symbol, 'A')
+                    test.assertEqual(trade._tp_order.symbol, 'A')
+                    test.assertIn('A', repr(self.positions['A']))
+
+        Backtest(dfs, S, commission=commission).run()
+        self.assertEqual(set(commission_symbols), {'A'})
+
+    # Indicators, containers, warmup #########################################
+
+    def test_container_indicators_sliced_progressively(self):
+        idx = self._index(20)
+        dfs = {s: self._df(np.r_[1:21.], idx) for s in 'AB'}
+        test = self
+        from collections import namedtuple
+        NT = namedtuple('NT', ['a', 'b'])
+
+        class S(_S):
+            def init(self):
+                arange = lambda: np.arange(len(self.data), dtype=float)  # noqa: E731
+                self.dct = {s: self.I(arange, name=f'{s}d', symbol=s) for s in 'AB'}
+                self.lst = [self.I(arange, name='l0'), self.I(arange, name='l1')]
+                self.tpl = (self.I(arange, name='t0'),)
+                self.nt = NT(self.I(arange, name='n0'), self.I(arange, name='n1'))
+
+            def next(self):
+                i = len(self.data) - 1
+                for s in 'AB':
+                    test.assertEqual(self.dct[s][-1], i)
+                    test.assertEqual(len(self.dct[s]), i + 1)
+                test.assertEqual(self.lst[0][-1], i)
+                test.assertEqual(self.tpl[0][-1], i)
+                test.assertEqual(self.nt.a[-1], i)
+                test.assertIsInstance(self.nt, NT)
+
+        Backtest(dfs, S).run()
+
+    def test_mixed_container_raises(self):
+        class S(_S):
+            def init(self):
+                self.mixed = {'ind': self.I(lambda: np.arange(len(self.data)), name='x'),
+                              'other': 42}
+
+            def next(self):
+                pass
+
+        bt = Backtest(SHORT_DATA, S)
+        self.assertRaisesRegex(ValueError, 'mixes indicators', bt.run)
+
+    def test_warmup_multiasset_groups(self):
+        idx = self._index(30)
+        a = self._df(np.r_[1:31.], idx)
+        b = self._df(np.r_[[np.nan] * 15, 16:31.], idx)  # Lists on bar 15
+        first_bar_seen = []
+
+        class S(Strategy):
+            def init(self):
+                self.sma = {s: self.I(SMA, self.data[s].Close, 5, symbol=s)
+                            for s in self.data.symbols}
+
+            def next(self):
+                first_bar_seen.append(len(self.data) - 1)
+
+        Backtest({'A': a, 'B': b}, S).run()
+        # A's SMA(5) is warm on bar 4; B's only on bar 19.
+        # Earliest-ready group wins (+1 for at least two entries available)
+        self.assertEqual(first_bar_seen[0], 5)
+
+        # An untagged indicator gates every group
+        first_bar_seen.clear()
+
+        class S2(S):
+            def init(self):
+                super().init()
+                self.gate = self.I(lambda: self.data['B'].Close * 1., name='gate')
+
+        Backtest({'A': a, 'B': b}, S2).run()
+        self.assertEqual(first_bar_seen[0], 16)
+
+        # A never-valid group is excluded rather than collapsing the warmup
+        first_bar_seen.clear()
+
+        class S3(S):
+            def init(self):
+                super().init()
+                self.dead = self.I(lambda: self.data['B'].Close * np.nan,
+                                   name='dead', symbol='B')
+
+        Backtest({'A': a, 'B': b}, S3).run()
+        self.assertEqual(first_bar_seen[0], 5)
+
+        # All groups never-valid => no simulation, with a warning
+        class S4(Strategy):
+            def init(self):
+                self.dead = self.I(lambda: self.data['A'].Close * np.nan, name='dead')
+
+            def next(self):
+                raise AssertionError('should never run')
+
+        with self.assertWarnsRegex(UserWarning, 'ever becomes non-NaN'):
+            stats = Backtest({'A': a, 'B': b}, S4).run()
+        self.assertEqual(stats['# Trades'], 0)
+
+    def test_indicator_master_length_enforced(self):
+        class S(_S):
+            def init(self):
+                self.I(lambda: self.data['A'].Close.s.dropna(), symbol='B', name='bad')
+
+            def next(self):
+                pass
+
+        idx = self._index(10)
+        a = self._df(np.r_[[np.nan] * 5, 6:11.], idx)
+        b = self._df(np.r_[1:11.], idx)
+        bt = Backtest({'A': a, 'B': b}, S)
+        self.assertRaisesRegex(ValueError, 'same length', bt.run)
+
+    # Stats ##################################################################
+
+    def test_multiasset_stats_and_benchmark(self):
+        idx = self._index(4)
+        a = self._df([10, 11, 12, 13], idx)                    # +10%, +9.09%, +8.33%
+        b = self._df([np.nan, 20, 22, np.nan], idx)            # lists bar 1, delists bar 3
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=1)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            stats = Backtest({'A': a, 'B': b}, S, finalize_trades=True).run()
+
+        # Equal-weight rebalanced basket:
+        # bar1: mean(10%) [B just listed, no return yet] -> hmm, B has return NaN on bar 1
+        r1 = (11 / 10 - 1)
+        r2 = np.mean([12 / 11 - 1, 22 / 20 - 1])
+        r3 = (13 / 12 - 1)  # B delisted, drops out
+        expected = (1 + r1) * (1 + r2) * (1 + r3) - 1
+        self.assertAlmostEqual(stats['Buy & Hold Return [%]'], expected * 100)
+
+        # Symbol column first, indicator masking N/A here
+        self.assertEqual(stats._trades.columns[0], 'Symbol')
+
+    def test_indicator_columns_masked_across_symbols(self):
+        idx = self._index(20)
+        dfs = {s: self._df(np.r_[1:21.], idx) for s in 'AB'}
+
+        class S(Strategy):
+            def init(self):
+                self.sma_a = self.I(SMA, self.data['A'].Close, 3, symbol='A')
+
+            def next(self):
+                if len(self.data) == 5:
+                    self.buy(symbol='A', size=1)
+                    self.buy(symbol='B', size=1)
+                if len(self.data) == 8:
+                    for trade in self.trades:
+                        trade.close()
+
+        stats = Backtest(dfs, S).run()
+        trades = stats._trades.set_index('Symbol')
+        col = [c for c in trades.columns if c.startswith('Entry_')][0]
+        self.assertFalse(np.isnan(trades.loc['A', col]))
+        self.assertTrue(np.isnan(trades.loc['B', col]))
+
+    def test_lib_compute_stats_multiasset_subset(self):
+        df = GOOG.iloc[:100]
+        with self._no_full_equity_warning():
+            stats = Backtest({'A': df, 'B': df * 2}, _PortfolioSmaCross,
+                             cash=100_000, finalize_trades=True).run()
+        trades_a = stats._trades[stats._trades.Symbol == 'A']
+        stats_a = compute_stats(stats=stats, trades=trades_a,
+                                data=pd.concat({'A': df, 'B': df * 2}, axis=1))
+        self.assertEqual(stats_a['# Trades'], len(trades_a))
+
+    # Finalization ###########################################################
+
+    def test_finalize_trades_settles_delisted_symbol(self):
+        idx = self._index(6)
+        a = self._df([10, 11, 12, 13, 14, 15], idx)
+        b = self._df([20, 21, 22, 23, np.nan, np.nan], idx)
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=1)
+                    self.buy(symbol='B', size=1)
+
+        stats = Backtest({'A': a, 'B': b}, S, finalize_trades=True).run()
+        trades = stats._trades.set_index('Symbol')
+        self.assertEqual(len(trades), 2)
+        # B settles at its last traded close, stamped on its last traded bar
+        self.assertEqual((trades.loc['B', 'ExitBar'], trades.loc['B', 'ExitPrice']), (3, 23))
+        # A closes through the regular end-of-run pipeline on the last bar
+        self.assertEqual((trades.loc['A', 'ExitBar'], trades.loc['A', 'ExitPrice']), (5, 15))
+        self.assertEqual(len(stats._strategy._broker.trades), 0)
+        self.assertEqual(len(stats._strategy.orders), 0)
+
+    # Plotting & optimization ################################################
+
+    def test_plot_multiasset(self):
+        df = GOOG.iloc[:100]
+        dfs = {'A': df, 'B': (df.iloc[30:] * 2).round(1)}
+        with self._no_full_equity_warning():
+            bt = Backtest(dfs, _PortfolioSmaCross, cash=100_000, finalize_trades=True)
+            stats = bt.run()
+        self.assertRaisesRegex(ValueError, 'Symbols', bt.plot, results=stats,
+                               open_browser=False)
+        self.assertRaisesRegex(ValueError, 'Unknown symbol', bt.plot, results=stats,
+                               symbol='Z', open_browser=False)
+        for symbol in ('A', 'B'):
+            with _tempfile() as f:
+                bt.plot(results=stats, symbol=symbol, filename=f, open_browser=False)
+                self.assertLess(100, os.path.getsize(f))
+
+        # Single-asset plot() must reject symbol=
+        bt1 = Backtest(df, SmaCross)
+        bt1.run()
+        self.assertRaisesRegex(ValueError, 'multi-asset', bt1.plot,
+                               symbol='A', open_browser=False)
+
+    def test_optimize_multiasset(self):
+        df = GOOG.iloc[:100]
+        with self._no_full_equity_warning(), warnings.catch_warnings():
+            warnings.filterwarnings('ignore', message='.*Searching for best.*')
+            bt = Backtest({'A': df, 'B': df * 2}, _PortfolioSmaCross, cash=100_000)
+            stats = bt.optimize(fast=[5, 10], slow=[15, 25])
+        self.assertGreater(stats['# Trades'], 0)
+
+    def test_shared_memory_multiindex_roundtrip(self):
+        from backtesting._util import SharedMemoryManager
+        df = pd.concat({'A': GOOG.iloc[:30], 'B': GOOG.iloc[:30] * 2}, axis=1)
+        with SharedMemoryManager(create=True) as smm:
+            shm = smm.df2shm(df)
+            df2, shms = SharedMemoryManager.shm2df(shm)
+            try:
+                self.assertIsInstance(df2.columns, pd.MultiIndex)
+                assert_frame_equal(df, df2, check_names=False)
+            finally:
+                for s in shms:
+                    s.close()
+
+    def test_fractional_backtest_rejects_multiasset(self):
+        self.assertRaises(TypeError, FractionalBacktest, {'A': GOOG}, SmaCross)
+        self.assertRaises(TypeError, FractionalBacktest,
+                          pd.concat({'A': GOOG}, axis=1), SmaCross)
+
+    # Review-driven regression tests #########################################
+
+    def test_commission_callable_signatures(self):
+        # Legacy 2-arg callable with an extra defaulted param: called with 2 args
+        def commission_defaulted(order_size, price, fee_rate=.001):
+            return abs(order_size) * price * fee_rate
+
+        class BuyOnce(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(size=1)
+
+        stats = Backtest(SHORT_DATA, BuyOnce, commission=commission_defaulted,
+                         finalize_trades=True).run()
+        self.assertGreater(stats._trades['Commission'].iloc[0], 0)
+
+        # Keyword-only `symbol` param receives the symbol in multi-asset mode
+        seen = []
+
+        def commission_kwonly(order_size, price, *, symbol=None):
+            seen.append(symbol)
+            return 0.
+
+        class BuyA(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='A', size=1)
+
+        idx = self._index(4)
+        dfs = {s: self._df([10, 11, 12, 13], idx) for s in 'AB'}
+        Backtest(dfs, BuyA, commission=commission_kwonly, finalize_trades=True).run()
+        self.assertEqual(set(seen), {'A'})
+
+        # *args callables keep the legacy 2-arg convention
+        def commission_varargs(*args):
+            assert len(args) == 2, args
+            return 0.
+
+        Backtest(SHORT_DATA, BuyOnce, commission=commission_varargs).run()
+
+    def test_settlement_equity_includes_commissions(self):
+        idx = self._index(6)
+        a = self._df([10.] * 6, idx)
+        b = self._df([20, 21, 22, 23, np.nan, np.nan], idx)
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    self.buy(symbol='B', size=5)
+
+        stats = Backtest({'A': a, 'B': b}, S, cash=1000, commission=.01,
+                         finalize_trades=True).run()
+        # All trades closed => final equity must equal cash + sum of trade PnLs
+        self.assertAlmostEqual(stats['Equity Final [$]'],
+                               1000 + stats._trades.PnL.sum())
+
+    def test_finalize_leaves_last_bar_entries_open_like_upstream(self):
+        class S(_S):
+            def next(self):
+                if len(self.data) == len(SHORT_DATA):
+                    self.buy(size=1)  # Fills during the finalize re-run
+
+        stats = Backtest(SHORT_DATA, S, finalize_trades=True).run()
+        # Upstream leaves the just-opened trade open and out of stats
+        self.assertEqual(len(stats._trades), 0)
+        self.assertEqual(len(stats._strategy._broker.trades), 1)
+
+    def test_warmup_object_dtype_indicator(self):
+        first_bar_seen = []
+
+        class S(_S):
+            def init(self):
+                values = [None] * 5 + [1.] * (len(self.data) - 5)
+                self.ind = self.I(lambda: np.asarray(values, dtype=object), name='obj')
+
+            def next(self):
+                first_bar_seen.append(len(self.data) - 1)
+
+        Backtest(SHORT_DATA, S).run()
+        # Object-dtype numeric indicators still contribute their NaN warm-up
+        self.assertEqual(first_bar_seen[0], 6)
+
+    def test_unknown_symbol_subscript_suggestion(self):
+        test = self
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    test.assertRaisesRegex(
+                        AttributeError, "Did you mean: 'GOOG'",
+                        lambda: self.data['GOOX'])
+
+        Backtest({'GOOG': SHORT_DATA, 'AAPL': SHORT_DATA}, S).run()
+
+    def test_positions_mapping_read_only(self):
+        test = self
+
+        class S(_S):
+            def next(self):
+                if len(self.data) == 2:
+                    with test.assertRaises(TypeError):
+                        self.positions['A'] = None
+
+        Backtest({'A': SHORT_DATA}, S).run()
+
+
+class _PortfolioSmaCross(Strategy):
+    fast, slow = 10, 30
+
+    def init(self):
+        self.sma1 = {s: self.I(SMA, self.data[s].Close, self.fast, symbol=s)
+                     for s in self.data.symbols}
+        self.sma2 = {s: self.I(SMA, self.data[s].Close, self.slow, symbol=s)
+                     for s in self.data.symbols}
+
+    def next(self):
+        for s in self.data.symbols:
+            if np.isnan(self.data[s].Close[-1]):
+                continue
+            if crossover(self.sma1[s], self.sma2[s]):
+                self.buy(symbol=s, size=.3)
+            elif crossover(self.sma2[s], self.sma1[s]) and self.positions[s]:
+                self.positions[s].close()


### PR DESCRIPTION
Backtest(data=...) now also accepts a dict of OHLC data frames keyed by asset symbol (or one data frame with two-level (symbol, field) columns), trading all assets from a single shared cash/margin account.

Design notes:
* Data is aligned on the union of the assets' indexes; bars on which an asset didn't trade are all-NaN and are never forward- or back-filled. Orders in such symbols remain queued (GTC) and can only fill at prices the symbol actually traded at (market orders at its next traded bar's open); limit/stop/SL/TP conditions are only evaluated on traded bars, with the existing pessimistic gap-through rules on resume. This, plus the existing progressive bar revelation (now propagated to per-symbol data views), prevents look-ahead bias.
* Open trades are marked to market at each symbol's most recent traded close; hedging/exclusive_orders/FIFO netting apply per symbol; margin, cash and equity are account-level.
* Strategy API: data[symbol] / data.symbols, buy/sell/I(symbol=...), positions[symbol], Order.symbol / Trade.symbol, plot(symbol=...).
* Warm-up in multi-asset mode starts the backtest when the earliest-ready symbol's indicator group (plus unassociated indicators) is non-NaN.
* Multi-asset 'Buy & Hold Return [%]' and the Alpha/Beta benchmark use an equal-weighted, per-bar-rebalanced basket of all assets; stats._trades gains a leading 'Symbol' column.
* Indicators held in flat dict/list/tuple attributes are now auto-sliced in Strategy.next() like plain indicator attributes (mixed containers raise), closing an accidental look-ahead loophole.
* finalize_trades=True settles trades whose symbol has no bar on the final timestamp at the symbol's last traded close.

Single-asset behavior is unchanged; the existing test suite passes as before.


Claude-Session: https://claude.ai/code/session_016fnus35BNzJnkjsC9AhaZM