### PR TITLE
Fix MultiBacktest mixed no-trade results

### DIFF
--- a/backtesting/lib.py
+++ b/backtesting/lib.py
@@ -608,7 +608,7 @@ class MultiBacktest:
         data_shm, strategy, bt_kwargs, run_kwargs = args
         dfs, shms = zip(*(SharedMemoryManager.shm2df(i) for i in data_shm))
         try:
-            return [stats.filter(regex='^[^_]') if stats['# Trades'] else None
+            return [stats.filter(regex='^[^_]')
                     for stats in (Backtest(df, strategy, **bt_kwargs).run(**run_kwargs)
                                   for df in dfs)]
         finally:

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -982,30 +982,24 @@ class TestLib(TestCase):
                 print(start_method, time.monotonic() - start_time)
         plot_heatmaps(heatmap.mean(axis=1), open_browser=False)
 
+    class SometimesNoTrade(Strategy):
+        def init(self):
+            self._will_trade = len(self.data) == 20
+
+        def next(self):
+            if not self._will_trade:
+                return
+            if self.position:
+                self.position.close()
+            elif not self.closed_trades:
+                self.buy()
+
     def test_MultiBacktest_handles_mixed_no_trade_results(self):
-        class SometimesNoTrade(Strategy):
-            def init(self):
-                self._will_trade = len(self.data.index) == 20
-                self._has_bought = False
-
-            def next(self):
-                if not self._will_trade:
-                    return
-                if self.position:
-                    self.position.close()
-                elif not self._has_bought:
-                    self.buy()
-                    self._has_bought = True
-
         btm = MultiBacktest([GOOG.iloc[:20], GOOG.iloc[:21], GOOG.iloc[:22]],
-                            SometimesNoTrade, cash=100_000)
+                            self.SometimesNoTrade, cash=100_000)
         res = btm.run()
-        self.assertIsInstance(res, pd.DataFrame)
-        self.assertEqual(res.columns.tolist(), [0, 1, 2])
-        self.assertGreater(res.loc['# Trades', 0], 0)
-        self.assertEqual(res.loc['# Trades', 1], 0)
-        self.assertEqual(res.loc['# Trades', 2], 0)
-        self.assertFalse(isinstance(res.iloc[0, 0], pd.Series))
+        self.assertEqual(res.loc['# Trades'].tolist(), [1, 0, 0])
+        self.assertNotIsInstance(res.iloc[0, 0], pd.Series)
 
 
 class TestUtil(TestCase):

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -982,6 +982,31 @@ class TestLib(TestCase):
                 print(start_method, time.monotonic() - start_time)
         plot_heatmaps(heatmap.mean(axis=1), open_browser=False)
 
+    def test_MultiBacktest_handles_mixed_no_trade_results(self):
+        class SometimesNoTrade(Strategy):
+            def init(self):
+                self._will_trade = len(self.data.index) == 20
+                self._has_bought = False
+
+            def next(self):
+                if not self._will_trade:
+                    return
+                if self.position:
+                    self.position.close()
+                elif not self._has_bought:
+                    self.buy()
+                    self._has_bought = True
+
+        btm = MultiBacktest([GOOG.iloc[:20], GOOG.iloc[:21], GOOG.iloc[:22]],
+                            SometimesNoTrade, cash=100_000)
+        res = btm.run()
+        self.assertIsInstance(res, pd.DataFrame)
+        self.assertEqual(res.columns.tolist(), [0, 1, 2])
+        self.assertGreater(res.loc['# Trades', 0], 0)
+        self.assertEqual(res.loc['# Trades', 1], 0)
+        self.assertEqual(res.loc['# Trades', 2], 0)
+        self.assertFalse(isinstance(res.iloc[0, 0], pd.Series))
+
 
 class TestUtil(TestCase):
     def test_as_str(self):


### PR DESCRIPTION
## Summary

Fixes #1344.
Closes https://github.com/kernc/backtesting.py/pull/1358

`MultiBacktest._mp_task_run()` currently returns `None` for datasets whose strategy produced zero trades. When a `MultiBacktest` run mixes datasets with trades and datasets with no trades, `MultiBacktest.run()` then receives a mixed list of `pd.Series` and `None`, which can either raise `TypeError: object of type 'NoneType' has no len()` or produce nested/odd DataFrame values depending on ordering.

`Backtest.run()` already returns a complete stats series for zero-trade strategies, so this change keeps those stats instead of replacing them with `None`.

## Changes

- Always return filtered stats from `_mp_task_run()`, including zero-trade stats.
- Add a regression test for mixed trade/no-trade datasets.
- Assert zero-trade datasets report `# Trades == 0` and do not produce nested Series values.

## Test plan

```bash
python -m unittest backtesting.test._test.TestLib.test_MultiBacktest_handles_mixed_no_trade_results
python -m unittest backtesting.test._test.TestLib.test_MultiBacktest
python -m unittest backtesting.test._test.TestBacktest.test_run backtesting.test._test.TestUtil.test_as_str
python -m compileall -q backtesting
flake8 backtesting setup.py
```
