### PR TITLE
BUG: Preserve stop-loss value in stats._trades when SL is gapped through

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -916,8 +916,11 @@ class _Broker:
                 if trade in self.trades:
                     self._reduce_trade(trade, price, size, time_index)
                     assert order.size != -_prev_size or trade not in self.trades
-                    if price == stop_price:
+                    if order is trade._sl_order:
                         # Set SL back on the order for stats._trades["SL"]
+                        # (it was cleared above when the stop was hit). Restore it
+                        # even when the SL was gapped through and the fill price is
+                        # worse than the stop price (i.e. `price != stop_price`).
                         trade._sl_order._replace(stop_price=stop_price)
                 if order in (trade._sl_order,
                              trade._tp_order):

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -1254,8 +1254,8 @@ class TestRegressions(TestCase):
         trades = Backtest(SHORT_DATA, S).run()._trades
         self.assertEqual(len(trades), 1)
         trade = trades.iloc[0]
-        # The long SL (99.5) is gapped through on the next bar's open (99.19),
-        # so the exit price is below the stop price ...
-        self.assertLess(trade['ExitPrice'], 99.5)
+        # The long SL (99.5) is gapped through on the next bar's open, so the
+        # trade exits at that worse market price rather than at the stop price.
+        self.assertEqual(trade['ExitPrice'], 99.19)
         # ... yet the SL value must be preserved in the trades data frame.
         self.assertEqual(trade['SL'], 99.5)

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -1177,3 +1177,21 @@ class TestRegressions(TestCase):
         trades = Backtest(SHORT_DATA, S).run()._trades
         self.assertEqual(trades['SL'].fillna(0).tolist(), [0, 99])
         self.assertEqual(trades['TP'].fillna(0).tolist(), [111, 0])
+
+    def test_sl_value_in_trades_df_when_gapped_through(self):
+        # An SL that is gapped through (the bar opens beyond the stop, so the
+        # fill price is worse than the stop price) must still be recorded in
+        # stats._trades["SL"]. See GH issue #1340.
+        class S(_S):
+            def next(self):
+                if len(self.data.index) == 9:
+                    self.buy(size=1, sl=99.5)
+
+        trades = Backtest(SHORT_DATA, S).run()._trades
+        self.assertEqual(len(trades), 1)
+        trade = trades.iloc[0]
+        # The long SL (99.5) is gapped through on the next bar's open (99.19),
+        # so the exit price is below the stop price ...
+        self.assertLess(trade['ExitPrice'], 99.5)
+        # ... yet the SL value must be preserved in the trades data frame.
+        self.assertEqual(trade['SL'], 99.5)


### PR DESCRIPTION
### Problem

When a trade is closed by its stop-loss, the SL value is sometimes missing (`NaN`) in `stats._trades["SL"]`, even though an SL was explicitly set. This happens specifically when the price **gaps through** the stop: the bar opens beyond the stop price, so the fill price is worse than the stop.

This is the still-unfixed part of #1288 reported in #1340.

### Root cause

When a stop order is hit, the stop becomes a market order and its `stop_price` is cleared:

```python
order._replace(stop_price=None)
```

Since the trade reads its SL from `trade._sl_order.stop`, clearing it drops the value from the trades data frame. The previous fix (#1288) restored it, but only when the fill price equalled the stop exactly:

```python
if price == stop_price:
    trade._sl_order._replace(stop_price=stop_price)
```

On a gap-through, the order fills at the (worse) open price, so `price != stop_price` and the SL is never restored.

### Fix

Restore the recorded SL whenever the executed order is the trade's own stop-loss order, regardless of the fill price. The `TP`/`trade.close()` paths are unaffected (those orders carry no stop price).

### Test

Added `test_sl_value_in_trades_df_when_gapped_through`, which enters a long position whose SL (99.5) is gapped through on the next bar's open (99.19). The exit price is below the stop, but the SL value must still be recorded.

- Red on `master`: `AssertionError: None != 99.5`
- Green with this change.

Existing SL/TP regression tests (`test_sl_tp_values_in_trades_df`, `test_sl_always_before_tp`, `test_stop_entry_and_tp_in_same_bar`) still pass.

Fixes #1340

Fixes https://github.com/kernc/backtesting.py/issues/1370