### PR TITLE
DOC: Clarify fractional order size semantics

### DIFF
--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -454,6 +454,8 @@ class Order:
         If size is a value between 0 and 1, it is interpreted as a fraction of current
         available liquidity (cash plus `Position.pl` minus used margin).
         A value greater than or equal to 1 indicates an absolute number of units.
+        Fractional sizing determines the order's cash allocation, not the
+        maximum account risk if the order's stop-loss is hit.
         """
         return self.__size
 

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -452,10 +452,9 @@ class Order:
         Order size (negative for short orders).
 
         If size is a value between 0 and 1, it is interpreted as a fraction of current
-        available liquidity (cash plus `Position.pl` minus used margin).
+        available liquidity (cash plus `Position.pl` minus used margin) to allocate
+        to the order (not the maximum account risk if the order's stop-loss is hit).
         A value greater than or equal to 1 indicates an absolute number of units.
-        Fractional sizing determines the order's cash allocation, not the
-        maximum account risk if the order's stop-loss is hit.
         """
         return self.__size
 


### PR DESCRIPTION
Clarifies the `Order.size` documentation for fractional sizes.

The existing docs correctly say that `0 < size < 1` is interpreted as a fraction of current available liquidity. This small addition makes explicit that fractional sizing controls order cash allocation, not the maximum account risk if a stop-loss is hit.

This is a documentation-only change. I ran:

```bash
python -m py_compile backtesting/backtesting.py
```