### PR TITLE
Preserve source timezone in chart timestamps

### DIFF
--- a/backtesting/_plotting.py
+++ b/backtesting/_plotting.py
@@ -76,6 +76,13 @@ def _windos_safe_filename(filename):
     return filename
 
 
+
+def _remove_timezone(values):
+    if isinstance(values, pd.DatetimeIndex):
+        return values.tz_localize(None) if values.tz is not None else values
+    if isinstance(values, pd.Series) and isinstance(values.dtype, pd.DatetimeTZDtype):
+        return values.dt.tz_localize(None)
+    return values
 def _bokeh_reset(filename=None):
     curstate().reset()
     if filename:
@@ -239,7 +246,7 @@ def plot(*, results: pd.Series,
             resample, df, indicators, equity_data, trades)
 
     df.index.name = None  # Provides source name @index
-    df['datetime'] = df.index  # Save original, maybe datetime index
+    df['datetime'] = _remove_timezone(df.index)  # Save original, maybe datetime index
     df = df.reset_index(drop=True)
     equity_data = equity_data.reset_index(drop=True)
     index = df.index

--- a/backtesting/_plotting.py
+++ b/backtesting/_plotting.py
@@ -75,6 +75,7 @@ def _windos_safe_filename(filename):
         return re.sub(r'[^a-zA-Z0-9,_-]', '_', filename.replace('=', '-'))
     return filename
 
+
 def _remove_timezone(values):
     if isinstance(values, pd.DatetimeIndex):
         return values.tz_localize(None) if values.tz is not None else values

--- a/backtesting/_plotting.py
+++ b/backtesting/_plotting.py
@@ -75,14 +75,14 @@ def _windos_safe_filename(filename):
         return re.sub(r'[^a-zA-Z0-9,_-]', '_', filename.replace('=', '-'))
     return filename
 
-
-
 def _remove_timezone(values):
     if isinstance(values, pd.DatetimeIndex):
         return values.tz_localize(None) if values.tz is not None else values
     if isinstance(values, pd.Series) and isinstance(values.dtype, pd.DatetimeTZDtype):
         return values.dt.tz_localize(None)
     return values
+
+
 def _bokeh_reset(filename=None):
     curstate().reset()
     if filename:
@@ -275,7 +275,7 @@ def plot(*, results: pd.Series,
 
     trade_source = ColumnDataSource(dict(
         index=trades['ExitBar'],
-        datetime=trades['ExitTime'],
+        datetime=_remove_timezone(trades['ExitTime']),
         size=trades['Size'],
         returns_positive=(trades['ReturnPct'] > 0).astype(int).astype(str),
     ))


### PR DESCRIPTION
## What does this PR do?

Timezone-aware OHLC and trade timestamps were passed directly to Bokeh, which normalizes them to UTC. This keeps the source wall-clock values consistent with the input timezone before they are sent to the chart.

Fixes #1065