### PR TITLE
BUG: Isolate stats repr from global float formatter

### DIFF
--- a/backtesting/_stats.py
+++ b/backtesting/_stats.py
@@ -196,6 +196,7 @@ class _Stats(pd.Series):
             'display.max_colwidth', 20,  # Prevent expansion due to _equity and _trades dfs
             'display.max_rows', len(self),  # Reveal self whole
             'display.precision', 5,  # Enough for my eyes at least
+            'display.float_format', None,  # Ignore invalid user-defined formatters
         ):
             # XXX: .fillna(nan) to replace None which aren't na_rep'd otherwise (pandas 3.0).
             #   Replace with proper na_rep option when that becomes available.

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -17,7 +17,7 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 
 from backtesting import Backtest as _Backtest, Strategy
-from backtesting._stats import compute_drawdown_duration_peaks
+from backtesting._stats import _Stats, compute_drawdown_duration_peaks
 from backtesting._util import _Array, _as_str, _Indicator, patch, try_
 from backtesting.lib import (
     FractionalBacktest, MultiBacktest, OHLCV_AGG,
@@ -389,6 +389,16 @@ class TestBacktest(TestCase):
                     'SL', 'TP', 'PnL', 'ReturnPct', 'EntryTime', 'ExitTime',
                     'Duration', 'Tag', 'Commission',
                     *indicator_columns]))
+
+    def test_stats_repr_ignores_invalid_global_float_format(self):
+        def invalid_float_format(value):
+            return f'{value:.2f}' if value else None
+
+        with pd.option_context('display.float_format', invalid_float_format):
+            representation = repr(_Stats({'Sortino Ratio': 0.}, dtype=object))
+            self.assertIs(pd.options.display.float_format, invalid_float_format)
+
+        self.assertIn('Sortino Ratio    0.0', representation)
 
     def test_compute_stats_bordercase(self):
 


### PR DESCRIPTION
  Description

  ## Summary

  Fixes #1255.

  Printing backtest stats can raise:

  ```text
  TypeError: object of type 'NoneType' has no len()

  The failure appears first at Sortino Ratio when its value is zero. Removing that field only moves
  the error to another zero-valued metric such as Volatility (Ann.) [%] or CAGR [%].

  ## Root cause

  _Stats.__repr__() inherits the process-wide pd.options.display.float_format setting.

  In the reported scenario, the configured formatter effectively behaves like:

  def float_format(value):
      return f'{value:.2f}' if value else None

  Pandas may pass 0.0 to this callable while formatting the stats series. The callable returns
  None, although pandas expects a string, and pandas later fails while calculating the formatted
  value's width.

  Although the formatter violates pandas' callable contract, an unrelated global display option
  should not make _Stats.__repr__() fail.

  ## Fix

  - Temporarily set display.float_format to None inside _Stats.__repr__().
  - Keep the override scoped to the existing pd.option_context, so the caller's global formatter is
    restored afterward.

  - Add a regression test covering a zero-valued Sortino Ratio and a formatter that returns None
    for zero.

  ## Test

  Added test_stats_repr_ignores_invalid_global_float_format.

  - [x] Confirmed the pre-fix path raises TypeError: object of type 'NoneType' has no len().
  - [x] Confirmed stats render successfully with the fix.
  - [x] Confirmed the caller's global float formatter remains configured after rendering.
  - [x] Full suite with pandas 2.2.3: 81 tests passed, 1 skipped.
  - [x] Full suite with pandas 3.0.5: 81 tests passed, 1 skipped.