### PR TITLE
BUG: Size shared memory by materialized array, not lazy Index.nbytes

### DIFF
--- a/backtesting/_util.py
+++ b/backtesting/_util.py
@@ -309,7 +309,9 @@ class SharedMemoryManager:
     def arr2shm(self, vals):
         """Array to shared memory. Returns (shm_name, shape, dtype) used for restore."""
         assert vals.ndim == 1, (vals.ndim, vals.shape, vals)
-        shm = self.SharedMemory(size=vals.nbytes, create=True)
+        # Not `vals.nbytes`; lazy indexes (e.g. RangeIndex) report their own,
+        # constant size rather than that of the array they materialize into
+        shm = self.SharedMemory(size=vals.size * vals.dtype.base.itemsize, create=True)
         # np.array can't handle pandas' tz-aware datetimes
         # https://github.com/numpy/numpy/issues/18279
         buf = np.ndarray(vals.shape, dtype=vals.dtype.base, buffer=shm.buf)

--- a/backtesting/test/_test.py
+++ b/backtesting/test/_test.py
@@ -1273,6 +1273,16 @@ class TestRegressions(TestCase):
         res = Backtest(data, SmaCross).optimize(fast=range(2, 3), slow=range(4, 5))
         self.assertGreater(res['# Trades'], 0)
 
+    def test_optimize_range_index(self):
+        # Data is passed to the workers through shared memory sized by
+        # `.nbytes`, which a lazy RangeIndex under-reports, previously raising
+        # "TypeError: buffer is too small for requested array". See GH issue #1237.
+        data: pd.DataFrame = GOOG.iloc[:100].reset_index(drop=True)
+        with self.assertWarnsRegex(UserWarning, 'index is not datetime'):
+            bt = Backtest(data, SmaCross)
+        res = bt.optimize(fast=range(2, 3), slow=range(4, 5))
+        self.assertGreater(res['# Trades'], 0)
+
     def test_sl_tp_values_in_trades_df(self):
         class S(_S):
             def next(self):


### PR DESCRIPTION
Fixes #1237.

## The bug

`Backtest.optimize(method='grid')` fails with `TypeError: buffer is too small for requested array` whenever the data has a **RangeIndex**, while `bt.run()` on the same data works fine.

Root cause in `SharedMemoryManager.arr2shm` (`backtesting/_util.py`): the shared-memory block is sized with `vals.nbytes`, but RangeIndex is lazy — its `.nbytes` reports the size of the underlying `range` object itself (a constant 132 bytes), not the int64 array it materializes into. The very next line builds `np.ndarray(vals.shape, dtype=vals.dtype.base, buffer=shm.buf)`, which needs `8 × len(index)` bytes. Measured: `pd.RangeIndex(44640).nbytes == 132` vs 357 120 bytes required — so any range-indexed frame longer than 16 rows overflows.

Contrary to the issue title, size is not the real variable — index type is. The "under 10 000 rows works" observations in the thread were almost certainly datetime-indexed runs, and range-indexed data is an explicitly documented input (`Backtest.__init__`: "a monotonic range index (i.e. a sequence of periods)").

## The fix

Size the block from the same `shape`/`dtype.base` pair the buffer view is built with: `vals.size * vals.dtype.base.itemsize`. For every eager index in play (`Index[int64]`, `DatetimeIndex`, tz-aware `DatetimeIndex`, float Series) this equals `.nbytes`, so only the broken RangeIndex path changes behavior.

## Validation

- New regression test `test_optimize_range_index` (placed next to the closely-related `test_optimize_datetime_index_with_timezone`): red on master with the exact `TypeError` from the issue, green with the fix.
- Correctness beyond not-crashing: with a real `multiprocessing.Pool` (not the Windows thread fallback), a 4-point grid on range-indexed GOOG returns the same best equity (81 812.37) as four independently computed serial `bt.run()` calls.
- `python -m backtesting.test`: 81 tests, OK (1 skipped).
- `flake8`: clean. `mypy`: error list byte-identical to master (all pre-existing, none introduced).